### PR TITLE
Player tab fixes

### DIFF
--- a/gui/tabs/players_tab.cpp
+++ b/gui/tabs/players_tab.cpp
@@ -1185,23 +1185,29 @@ namespace PlayersTab {
 			}
 			if (openPUID && selectedPlayer.has_value()) {
 				ImGui::Dummy(ImVec2(3, 3) * State.dpiScale);
-				if (convert_from_string(selectedPlayer.get_PlayerData()->fields.Puid) != "" && ImGui::Button("Steal Data")) {
-					State.FakePuid = convert_from_string(selectedPlayer.get_PlayerData()->fields.Puid);
-					State.FakeFriendCode = convert_from_string(selectedPlayer.get_PlayerData()->fields.FriendCode);
+				if (ImGui::Button("Steal Data")) {
+					State.StealedPUID = convert_from_string(selectedPlayer.get_PlayerData()->fields.Puid);
+					State.StealedFC = convert_from_string(selectedPlayer.get_PlayerData()->fields.FriendCode);
 					State.Save();
 				}
 				ImGui::Dummy(ImVec2(15, 15) * State.dpiScale);
-				if (InputString("PUID", &State.FakePuid)) {
+				if (InputString("PUID", &State.StealedPUID)) {
 					State.Save();
 				}
 				ImGui::Dummy(ImVec2(2, 2) * State.dpiScale);
-				if (InputString("Friend Code", &State.FakeFriendCode)) {
+				if (InputString("Friend Code", &State.StealedFC)) {
 					State.Save();
 				}
-				if (convert_from_string(selectedPlayer.get_PlayerData()->fields.Puid) != "" && ImGui::Button("Copy PUID"))
-					ClipboardHelper_PutClipboardString(selectedPlayer.get_PlayerData()->fields.Puid, NULL);
-				if (convert_from_string(selectedPlayer.get_PlayerData()->fields.FriendCode) != "" && ImGui::Button("Copy Friend Code"))
-					ClipboardHelper_PutClipboardString(selectedPlayer.get_PlayerData()->fields.FriendCode, NULL);
+				ImGui::Dummy(ImVec2(10, 10)* State.dpiScale);
+				{
+					if (convert_from_string(selectedPlayer.get_PlayerData()->fields.Puid) != "" && ImGui::Button("Copy PUID"))
+						ClipboardHelper_PutClipboardString(selectedPlayer.get_PlayerData()->fields.Puid, NULL);
+				}
+				ImGui::SameLine();
+				{
+					if (convert_from_string(selectedPlayer.get_PlayerData()->fields.FriendCode) != "" && ImGui::Button("Copy Friend Code"))
+						ClipboardHelper_PutClipboardString(selectedPlayer.get_PlayerData()->fields.FriendCode, NULL);
+				}
 			}
 			ImGui::EndChild();
 		}

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -365,6 +365,8 @@ void Settings::Save() {
                 { "GuestFriendCode", this->GuestFriendCode },
                 { "FakeFriendCode", this->FakeFriendCode },
                 { "FakePuid", this->FakePuid },
+                { "StealedFC", this->StealedFC },
+                { "StealedPUID", this->StealedPUID },
                 { "SpoofPlatform", this->SpoofPlatform },
                 { "RPCSpoof", this->RPCSpoof },
                 { "FakePlatform", this->FakePlatform },

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -57,6 +57,8 @@ public:
     std::string GuestFriendCode = "";
     std::string FakeFriendCode = "";
     std::string FakePuid = "";
+    std::string StealedFC = "";
+    std::string StealedPUID = "";
     bool SpoofPlatform = false;
     bool RPCSpoof = false;
     int FakePlatform = 0;


### PR DESCRIPTION
Small crash-fix in PUID tab [not depends to general crash from ``Trolling`` tab, when you selecting {player}]
Some changes in ``PUID`` tab, Added separately StealedFC & StealedPUID