### PR TITLE
Ban Everyone & Kick Everyone - Features

### DIFF
--- a/gui/tabs/game_tab.cpp
+++ b/gui/tabs/game_tab.cpp
@@ -636,7 +636,10 @@ namespace GameTab {
         }
 
         if (openDestruct) {
-            if (ToggleButton("Ignore Whitelisted Players", &State.Destruct_IgnoreWhitelist)) {
+            if (ToggleButton("Ignore Whitelisted Players [Exploits]", &State.Destruct_IgnoreWhitelist)) {
+                State.Save();
+            }
+            if (ToggleButton("Ignore Whitelisted Players [Ban/Kick Everyone]", &State.Ban_IgnoreWhitelist)) {
                 State.Save();
             }
             if (ToggleButton("Overload Everyone [Slow]", &State.OverloadEveryone)) {
@@ -650,6 +653,16 @@ namespace GameTab {
             }
             if (IsHost() && ImGui::Button("Remove Map")) {
                 State.taskRpcQueue.push(new DestroyMap());
+            }
+            ImGui::Dummy(ImVec2(10, 100)* State.dpiScale);
+            if ((IsHost()) && ToggleButton("Ban Everyone", &State.BanEveryone))
+            {
+                State.Save();
+            }
+            ImGui::SameLine();
+            if ((IsHost()) && ToggleButton("Kick Everyone", &State.KickEveryone))
+            {
+                State.Save();
             }
             if (State.CrashSpamReport) ImGui::TextColored(ImVec4(1.0f, 1.0f, 1.0f, 1.0f), ("When the game starts, the lobby is destroyed"));
             if (State.AprilFoolsMode) {

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -154,6 +154,9 @@ void dInnerNetClient_Update(InnerNetClient* __this, MethodInfo* method)
                     State.EnableZoom = false; //intended as we don't want stuff like the taskbar and danger meter disappearing on game start
                     State.FreeCam = false; //moving after game start / on joining new game
                     State.ChatFocused = false; //failsafe
+
+                    State.BanEveryone = false;
+                    State.KickEveryone = false;
                 }
             }
             else {

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -879,6 +879,52 @@ void dInnerNetClient_Update(InnerNetClient* __this, MethodInfo* method)
     else {
         AutoRepairSabotageDelay--;
     }
+    
+    static int AutoPunish = 1;
+
+    if (State.BanEveryone) {
+        for (int playerId = 0; playerId < Game::MAX_PLAYERS; ++playerId) {
+            auto playerData = GetPlayerDataById(playerId);
+            auto playerControl = GetPlayerControlById(playerId);
+
+            if (!playerData || !playerControl || playerControl == *Game::pLocalPlayer) continue;
+
+            if (State.Ban_IgnoreWhitelist &&
+                std::find(State.WhitelistFriendCodes.begin(), State.WhitelistFriendCodes.end(), convert_from_string(playerData->fields.FriendCode)) != State.WhitelistFriendCodes.end()) {
+                continue;
+            }
+
+            if (AutoPunish <= 0) {
+                app::InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), playerControl->fields._.OwnerId, true, NULL);
+                AutoPunish = 1; // Preventing the absence of notifications
+            }
+            else {
+                AutoPunish--;
+            }
+        }
+    }
+
+    if (State.KickEveryone) {
+        for (int playerId = 0; playerId < Game::MAX_PLAYERS; ++playerId) {
+            auto playerData = GetPlayerDataById(playerId);
+            auto playerControl = GetPlayerControlById(playerId);
+
+            if (!playerData || !playerControl || playerControl == *Game::pLocalPlayer) continue;
+
+            if (State.Ban_IgnoreWhitelist &&
+                std::find(State.WhitelistFriendCodes.begin(), State.WhitelistFriendCodes.end(), convert_from_string(playerData->fields.FriendCode)) != State.WhitelistFriendCodes.end()) {
+                continue;
+            }
+
+            if (AutoPunish <= 0) {
+                app::InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), playerControl->fields._.OwnerId, false, NULL);
+                AutoPunish = 1; // Preventing the absence of notifications
+            }
+            else {
+                AutoPunish--;
+            }
+        }
+    }
 }
 
 void dAmongUsClient_OnGameJoined(AmongUsClient* __this, String* gameIdString, MethodInfo* method) {

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -531,8 +531,11 @@ public:
     bool ProGamer = false;
 
     bool Destruct_IgnoreWhitelist = false;
+    bool Ban_IgnoreWhitelist = false;
     bool OverloadEveryone = false;
     bool LagEveryone = false;
+    bool BanEveryone = false;
+    bool KickEveryone = false;
 
     bool AprilFoolsMode = false;
     bool BrainrotEveryone = false;


### PR DESCRIPTION
## When activated, it automatically ban/kick all players in server [Host Only]

- Ban Everyone
- Kick Everyone
- Fix with notifications
- Separately we can activate anti-ban/anti-kick:
 ``Ignore Whitelisted Players [Ban/Kick Everyone]``