### PR TITLE
Ban Everyone & Kick Everyone - Features

### DIFF
--- a/gui/tabs/game_tab.cpp
+++ b/gui/tabs/game_tab.cpp
@@ -636,7 +636,10 @@ namespace GameTab {
         }
 
         if (openDestruct) {
-            if (ToggleButton("Ignore Whitelisted Players", &State.Destruct_IgnoreWhitelist)) {
+            if (ToggleButton("Ignore Whitelisted Players [Exploits]", &State.Destruct_IgnoreWhitelist)) {
+                State.Save();
+            }
+            if (ToggleButton("Ignore Whitelisted Players [Ban/Kick]", &State.Ban_IgnoreWhitelist)) {
                 State.Save();
             }
             if (ToggleButton("Overload Everyone [Slow]", &State.OverloadEveryone)) {

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -154,6 +154,9 @@ void dInnerNetClient_Update(InnerNetClient* __this, MethodInfo* method)
                     State.EnableZoom = false; //intended as we don't want stuff like the taskbar and danger meter disappearing on game start
                     State.FreeCam = false; //moving after game start / on joining new game
                     State.ChatFocused = false; //failsafe
+
+                    State.BanEveryone = false;
+                    State.KickEveryone = false;
                 }
             }
             else {
@@ -878,6 +881,52 @@ void dInnerNetClient_Update(InnerNetClient* __this, MethodInfo* method)
     }
     else {
         AutoRepairSabotageDelay--;
+    }
+
+        static int AutoPunish = 1;
+
+    if (State.BanEveryone) {
+        for (int playerId = 0; playerId < Game::MAX_PLAYERS; ++playerId) {
+            auto playerData = GetPlayerDataById(playerId);
+            auto playerControl = GetPlayerControlById(playerId);
+
+            if (!playerData || !playerControl || playerControl == *Game::pLocalPlayer) continue;
+
+            if (State.Ban_IgnoreWhitelist &&
+                std::find(State.WhitelistFriendCodes.begin(), State.WhitelistFriendCodes.end(), convert_from_string(playerData->fields.FriendCode)) != State.WhitelistFriendCodes.end()) {
+                continue;
+            }
+
+            if (AutoPunish <= 0) {
+                app::InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), playerControl->fields._.OwnerId, true, NULL);
+                AutoPunish = 1; // Preventing the absence of notifications
+            }
+            else {
+                AutoPunish--;
+            }
+        }
+    }
+
+    if (State.KickEveryone) {
+        for (int playerId = 0; playerId < Game::MAX_PLAYERS; ++playerId) {
+            auto playerData = GetPlayerDataById(playerId);
+            auto playerControl = GetPlayerControlById(playerId);
+
+            if (!playerData || !playerControl || playerControl == *Game::pLocalPlayer) continue;
+
+            if (State.Ban_IgnoreWhitelist &&
+                std::find(State.WhitelistFriendCodes.begin(), State.WhitelistFriendCodes.end(), convert_from_string(playerData->fields.FriendCode)) != State.WhitelistFriendCodes.end()) {
+                continue;
+            }
+
+            if (AutoPunish <= 0) {
+                app::InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), playerControl->fields._.OwnerId, false, NULL);
+                AutoPunish = 1; // Preventing the absence of notifications
+            }
+            else {
+                AutoPunish--;
+            }
+        }
     }
 }
 

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -531,8 +531,11 @@ public:
     bool ProGamer = false;
 
     bool Destruct_IgnoreWhitelist = false;
+    bool Ban_IgnoreWhitelist = false;
     bool OverloadEveryone = false;
     bool LagEveryone = false;
+    bool BanEveryone = false;
+    bool KickEveryone = false;
 
     bool AprilFoolsMode = false;
     bool BrainrotEveryone = false;


### PR DESCRIPTION
## When activated, it automatically ban/kick all players in server [Host Only]

- Ban Everyone
- Kick Everyone
- Notification fixes
- Separately we can activate ``Ignore Whitelisted Players [Ban/Kick]`` to prevent unnecessary bans