### PR TITLE
Fix ToggleButton "Clear After Meeting" not working (Replay)

### DIFF
--- a/gui/replay.cpp
+++ b/gui/replay.cpp
@@ -562,6 +562,9 @@ namespace Replay
 		ImGui::Dummy(ImVec2(1.0f, 5.0f) * State.dpiScale);
 
 		ImGui::BeginChild("replay#control", ImVec2(0,0), false, ImGuiWindowFlags_NoBackground);
+
+		if (State.Replay_IsLive && State.MatchCurrent != State.MatchLive)
+			State.MatchCurrent = State.MatchLive;
 		
 		SliderChrono("##replay_slider", &State.MatchCurrent, &State.MatchStart, &State.MatchLive, fmt, ImGuiSliderFlags_None);
 		

--- a/hooks/ExileController.cpp
+++ b/hooks/ExileController.cpp
@@ -10,6 +10,15 @@ void dExileController_ReEnableGameplay(ExileController* __this, MethodInfo* meth
 	if (State.ShowHookLogs) LOG_DEBUG("Hook dExileController_ReEnableGameplay executed");
 	app::ExileController_ReEnableGameplay(__this, method);
 
+	if (State.Replay_ClearAfterMeeting) {
+		State.ClearReplayData();
+		State.Replay_IsLive = true;
+		State.Replay_IsPlaying = true;
+		State.ShowReplay = true;
+		State.MatchCurrent = State.MatchLive;
+		if (State.ShowHookLogs) LOG_DEBUG("Replay Cleaned After Meeting");
+	}
+
 	try {// ESP: Reset Kill Cooldown
 		for (auto pc : GetAllPlayerControl()) {
 			if (auto player = PlayerSelection(pc).validate();

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -724,6 +724,13 @@ void Settings::Save() {
     }
 }
 
+void Settings::ClearReplayData() {
+    liveReplayEvents.clear();
+    replayWalkPolylineByPlayer.clear();
+    lastWalkEventPosPerPlayer.fill(ImVec2());
+    replayDeathTimePerPlayer.fill(std::chrono::system_clock::time_point());
+}
+
 void Settings::Delete() {
     auto path = getModulePath(hModule);
 

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -622,6 +622,7 @@ public:
     void Save();
     void SaveConfig();
     void Delete();
+    void ClearReplayData();
 };
 
 extern Settings State;


### PR DESCRIPTION
This pull request fixes the Clear After Meeting toggle in the Replay system, which was not properly clearing the recorded data after meetings as expected. The logic now correctly resets the replay state when a meeting ends.