### PR TITLE
abnormal task completion smac

### DIFF
--- a/gui/tabs/game_tab.cpp
+++ b/gui/tabs/game_tab.cpp
@@ -613,8 +613,17 @@ namespace GameTab {
             ImGui::SameLine();
             if (ToggleButton("Abnormal Vanish", &State.SMAC_CheckVanish)) State.Save();
 
+
             if (ToggleButton("Abnormal Meetings/Body Reports", &State.SMAC_CheckReport)) State.Save();
             ImGui::SameLine();
+            if (ToggleButton("Abnormal Venting", &State.SMAC_CheckVent)) State.Save();
+            ImGui::SameLine();
+           
+            if (ToggleButton("Abnormal Chat", &State.SMAC_CheckChat)) State.Save();
+
+            if (ToggleButton("Abnormal Task Completion", &State.SMAC_CheckTaskCompletion)) State.Save();
+            ImGui::SameLine();
+            if (ToggleButton("Abnormal Sabotages", &State.SMAC_CheckSabotage)) State.Save();
             if (ToggleButton("Abnormal Player Levels (0 to ignore)", &State.SMAC_CheckLevel)) State.Save();
             if (State.SMAC_CheckLevel && ImGui::InputInt("Level >=", &State.SMAC_HighLevel)) {
                 State.Save();
@@ -622,13 +631,6 @@ namespace GameTab {
             if (State.SMAC_CheckLevel && ImGui::InputInt("Level <=", &State.SMAC_LowLevel)) {
                 State.Save();
             }
-
-            if (ToggleButton("Abnormal Venting", &State.SMAC_CheckVent)) State.Save();
-            ImGui::SameLine();
-            if (ToggleButton("Abnormal Sabotages", &State.SMAC_CheckSabotage)) State.Save();
-            ImGui::SameLine();
-            if (ToggleButton("Abnormal Chat", &State.SMAC_CheckChat)) State.Save();
-
             if (ToggleButton("Blocked Words", &State.SMAC_CheckBadWords)) State.Save();
             if (State.SMAC_CheckBadWords) {
                 if (State.SMAC_BadWords.empty())

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -529,6 +529,7 @@ public:
     bool SMAC_CheckLevel = true;
     bool SMAC_CheckVent = true;
     bool SMAC_CheckSabotage = true;
+    bool SMAC_CheckTaskCompletion = true;
     int SMAC_HighLevel = 10000;
     int SMAC_LowLevel = 0;
     std::vector<uint8_t> SMAC_AttemptBanLobby = {};
@@ -574,6 +575,11 @@ public:
     int rpc101Counter = 0;
     const int RPC101_LIMIT = 30;
 
+    // Task anomaly detection [SMAC | Dependencies]
+    std::unordered_map<uint8_t, std::chrono::steady_clock::time_point> lastTaskCompletionTime;
+    std::unordered_map<uint8_t, int> taskCompletionCounter;
+    int MAX_TASK_COMPLETIONS = 3; // Max tasks that can be completed in the detection window
+    float TASK_DETECTION_WINDOW = 2.0f; //time in seconds 
 
     // Player tab [Crash-fix | Dependencies]
     std::unordered_map<uint8_t, std::chrono::steady_clock::time_point> newPlayersAppear;
@@ -581,7 +587,6 @@ public:
     std::unordered_set<uint8_t> finishedPlayers;
     std::unordered_set<uint8_t> currentPlayers;
     static constexpr float appearDuration = 0.5f;
-
 
     // Name-Checker [Dependencies]
     std::unordered_set<std::string> ForbiddenNames;


### PR DESCRIPTION
Adds a toggle in smac for abnormal task completion. Currently if 3 or more tasks are completed within 2 seconds it will flag. Can be changed in  state.hpp 
Formatting changed in smac the layout so all the detect actions are separate from the ones that have an input box eg abnormal level.