### PR TITLE
Add Anti Overload protection

### DIFF
--- a/appdata/il2cpp-functions.h
+++ b/appdata/il2cpp-functions.h
@@ -181,6 +181,7 @@ DO_APP_FUNC(void, InnerNetClient_KickPlayer, (InnerNetClient* __this, int32_t cl
 DO_APP_FUNC(void, AmongUsClient_KickNotJoinedPlayers, (AmongUsClient* __this, MethodInfo* method), "Assembly-CSharp, System.Void AmongUsClient::KickNotJoinedPlayers()");
 DO_APP_FUNC(void, InnerNetClient_SendStartGame, (InnerNetClient* __this, MethodInfo* method), "Assembly-CSharp, System.Void InnerNet.InnerNetClient::SendStartGame()");
 DO_APP_FUNC(void, InnerNetClient_Update, (InnerNetClient* __this, MethodInfo* method), "Assembly-CSharp, System.Void InnerNet.InnerNetClient::Update()");
+DO_APP_FUNC(void, InnerNetClient_HandleGameData, (InnerNetClient* __this, MessageReader* parentReader, MethodInfo* method), "Assembly-CSharp, System.Void InnerNet.InnerNetClient::HandleGameData(Hazel.MessageReader)");
 //DO_APP_FUNC(MessageWriter*, InnerNetClient_StartRpc, (InnerNetClient* __this, uint32_t targetNetId, uint8_t callId, SendOption__Enum option, MethodInfo* method), "Assembly-CSharp, Hazel.MessageWriter InnerNet.InnerNetClient::StartRpc(System.UInt32, System.Byte, Hazel.SendOption)");
 DO_APP_FUNC(MessageWriter*, InnerNetClient_StartRpcImmediately, (InnerNetClient* __this, uint32_t targetNetId, uint8_t callId, SendOption__Enum option, int32_t targetClientId, MethodInfo* method), "Assembly-CSharp, Hazel.MessageWriter InnerNet.InnerNetClient::StartRpcImmediately(System.UInt32, System.Byte, Hazel.SendOption, System.Int32)");
 DO_APP_FUNC(void, InnerNetClient_FinishRpcImmediately, (InnerNetClient* __this, MessageWriter* msg, MethodInfo* method), "Assembly-CSharp, System.Void InnerNet.InnerNetClient::FinishRpcImmediately(Hazel.MessageWriter)");
@@ -271,6 +272,7 @@ DO_APP_FUNC(void, PlayerPhysics_FixedUpdate, (PlayerPhysics* __this, MethodInfo*
 DO_APP_FUNC(void, PlayerPhysics_RpcEnterVent, (PlayerPhysics* __this, int32_t id, MethodInfo* method), "Assembly-CSharp, System.Void PlayerPhysics::RpcEnterVent(System.Int32)");
 DO_APP_FUNC(void, PlayerPhysics_RpcExitVent, (PlayerPhysics* __this, int32_t id, MethodInfo* method), "Assembly-CSharp, System.Void PlayerPhysics::RpcExitVent(System.Int32)");
 DO_APP_FUNC(void, PlayerPhysics_RpcBootFromVent, (PlayerPhysics* __this, int32_t ventId, MethodInfo* method), "Assembly-CSharp, System.Void PlayerPhysics::RpcBootFromVent(System.Int32)");
+DO_APP_FUNC(void, PlayerPhysics_HandleRpc, (PlayerPhysics* __this, uint8_t callId, MessageReader* reader, MethodInfo* method), "Assembly-CSharp, System.Void PlayerPhysics::HandleRpc(System.Byte, Hazel.MessageReader)");
 
 DO_APP_FUNC(void, PlayerControl_TurnOnProtection, (PlayerControl* __this, bool visible, int32_t colorId, int32_t guardianPlayerId, MethodInfo* method), "Assembly-CSharp, System.Void PlayerControl::TurnOnProtection(System.Boolean, System.Int32, System.Int32)");
 DO_APP_FUNC(void, PlayerControl_RemoveProtection, (PlayerControl* __this, MethodInfo* method), "Assembly-CSharp, System.Void PlayerControl::RemoveProtection()");

--- a/hooks/AntiOverload.cpp
+++ b/hooks/AntiOverload.cpp
@@ -1,0 +1,114 @@
+#include "pch-il2cpp.h"
+#include "_hooks.h"
+#include "state.hpp"
+#include "game.h"
+#include "logger.h"
+#include <unordered_map>
+#include <unordered_set>
+#include <queue>
+#include <chrono>
+
+using namespace app;
+using SteadyClock = std::chrono::steady_clock;
+using TimePoint = std::chrono::time_point<SteadyClock>;
+
+static const std::unordered_map<uint8_t, std::pair<int, float>> RpcLimits = {
+    { 18, {100, 0.1f} }, { 49, {100, 0.1f} }, { 44, {50,  0.1f} },
+    { 50, {100, 0.1f} }, { 21, {20,  0.1f} }, { 8,  {30,  0.1f} },
+    { 6,  {30,  0.1f} }, { 39, {30,  0.1f} }, { 40, {30,  0.1f} },
+    { 42, {30,  0.1f} }, { 41, {30,  0.1f} }, { 33, {1,   1.0f} },
+    { 54, {5,   1.0f} }, { 7,  {100, 0.1f} },
+};
+
+static const std::unordered_set<uint8_t> ImmediatelyRPCs = {
+    51,54,5,7,14,47,48,12,52,53,45,46,62,64,55,56,2,63,65,21
+};
+static const std::unordered_set<uint8_t> SusRPCs = { 101,164,154,85 };
+static const std::unordered_set<uint8_t> ExcludedNumMsg = { 41,39,40,42,43,38 };
+static const std::unordered_set<uint8_t> ExcludedForLobby = {
+    2,5,7,9,10,13,17,18,21,33,36,37,38,39,40,41,42,43,49,50,60,61,80,78,70,210,81,176
+};
+static const std::unordered_set<uint8_t> NormalCustomIds = { 80,78,70,210,81,176 };
+
+struct PlayerRpcTracker {
+    TimePoint joinTime;
+    std::unordered_map<uint8_t, std::queue<TimePoint>> timestamps;
+};
+static std::unordered_map<uint8_t, PlayerRpcTracker> g_trackers;
+
+static bool CheckSpam(PlayerRpcTracker& tracker, uint8_t callId) {
+    auto& q = tracker.timestamps[callId];
+    auto  now = SteadyClock::now();
+    int   maxCount = 10;
+    float window = 1.0f;
+    auto  lim = RpcLimits.find(callId);
+    if (lim != RpcLimits.end()) { maxCount = lim->second.first; window = lim->second.second; }
+    while (!q.empty()) {
+        if (std::chrono::duration<float>(now - q.front()).count() > window) q.pop(); else break;
+    }
+    q.push(now);
+    if ((int)q.size() > maxCount) {
+        LOG_DEBUG(("AntiOverload: RPC Spam id=" + std::to_string(callId) +
+            " (" + std::to_string(q.size()) + "/" + std::to_string(maxCount) + ")").c_str());
+        return false;
+    }
+    return true;
+}
+
+bool RpcCheck(PlayerControl* player, uint8_t callId, int numData) {
+    if (!player) return true;
+    if (Game::pLocalPlayer && player == *Game::pLocalPlayer) return true;
+    uint8_t pid = player->fields.PlayerId;
+    auto& tracker = g_trackers[pid];
+    float joinAge = std::chrono::duration<float>(SteadyClock::now() - tracker.joinTime).count();
+    if (joinAge < 3.0f) return true;
+    if (NormalCustomIds.count(callId)) return true;
+    if (SusRPCs.count(callId)) {
+        LOG_DEBUG(("AntiOverload: Sus RPC blocked id=" + std::to_string(callId)).c_str());
+        return false;
+    }
+    if (!CheckSpam(tracker, callId)) return false;
+    if (IsInLobby() && !ExcludedForLobby.count(callId)) {
+        LOG_DEBUG(("AntiOverload: Lobby RPC blocked id=" + std::to_string(callId)).c_str());
+        return false;
+    }
+    if (!ExcludedNumMsg.count(callId)) {
+        if (ImmediatelyRPCs.count(callId) && numData > 1) {
+            LOG_DEBUG(("AntiOverload: ImmediateRPC flood id=" + std::to_string(callId)).c_str());
+            return false;
+        }
+        if (numData > 10) {
+            LOG_DEBUG(("AntiOverload: Big data RPC id=" + std::to_string(callId)).c_str());
+            return false;
+        }
+    }
+    return true;
+}
+
+void AntiOverload_OnPlayerJoin(uint8_t playerId) {
+    g_trackers[playerId].joinTime = SteadyClock::now();
+    g_trackers[playerId].timestamps = {};
+}
+void AntiOverload_OnPlayerLeave(uint8_t playerId) {
+    g_trackers.erase(playerId);
+}
+
+void dPlayerPhysics_HandleRpc(PlayerPhysics* __this, uint8_t callId, MessageReader* reader, MethodInfo* method) {
+    if (State.AntiOverload && __this && __this->fields.myPlayer) {
+        auto* p = __this->fields.myPlayer;
+        if (!(Game::pLocalPlayer && p == *Game::pLocalPlayer))
+            if (!RpcCheck(p, callId, 1)) return;
+    }
+    PlayerPhysics_HandleRpc(__this, callId, reader, method);
+}
+
+void dInnerNetClient_HandleGameData(InnerNetClient* __this, MessageReader* parentReader, MethodInfo* method) {
+    if (State.AntiOverload && __this->fields.InOnlineScene) {
+        int32_t remaining = MessageReader_get_BytesRemaining(parentReader, NULL);
+        if (remaining > 300) { // 100 sub-messages * 3 bytes minimum each
+            LOG_DEBUG(("AntiOverload: Data flood blocked, bytes=" + std::to_string(remaining)).c_str());
+            return;
+        }
+    }
+    InnerNetClient_HandleGameData(__this, parentReader, method);
+}

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -1385,6 +1385,7 @@ void dAmongUsClient_OnPlayerLeft(AmongUsClient* __this, ClientData* data, Discon
                 Log.Debug(ToString(data->fields.Character) + " has left the game.");
 
             uint8_t playerId = data->fields.Character->fields.PlayerId;
+            AntiOverload_OnPlayerLeave(playerId);
 
             if (State.modUsers.find(playerId) != State.modUsers.end())
                 State.modUsers.erase(playerId);
@@ -1410,6 +1411,8 @@ void dAmongUsClient_OnPlayerLeft(AmongUsClient* __this, ClientData* data, Discon
 void dAmongUsClient_OnPlayerJoined(AmongUsClient* __this, ClientData* data, MethodInfo* method) {
     if (State.ShowHookLogs) LOG_DEBUG("Hook dAmongUsClient_OnPlayerJoined executed");
     State.BlinkPlayersTab = true;
+    if (data->fields.Character)
+        AntiOverload_OnPlayerJoin(data->fields.Character->fields.PlayerId);
     AmongUsClient_OnPlayerJoined(__this, data, method);
 }
 

--- a/hooks/PlayerControl.cpp
+++ b/hooks/PlayerControl.cpp
@@ -1071,6 +1071,9 @@ void dPlayerControl_StartMeeting(PlayerControl* __this, NetworkedPlayerInfo* tar
 
 void dPlayerControl_HandleRpc(PlayerControl* __this, uint8_t callId, MessageReader* reader, MethodInfo* method) {
     if (State.ShowHookLogs) LOG_DEBUG("Hook dPlayerControl_HandleRpc executed");
+    if (State.AntiOverload && __this)                                    
+        if (!(Game::pLocalPlayer && __this == *Game::pLocalPlayer))     
+            if (!RpcCheck(__this, callId, 1)) return;
     int32_t pos = reader->fields._position, head = reader->fields.readHead;
     try {
         if (State.IgnoreRPCs && callId != (uint8_t)RpcCalls__Enum::CheckName && callId != (uint8_t)RpcCalls__Enum::CheckColor && callId != (uint8_t)RpcCalls__Enum::SendChat)

--- a/hooks/_hooks.cpp
+++ b/hooks/_hooks.cpp
@@ -8,6 +8,7 @@
 #include "game.h"
 
 using namespace Game;
+using namespace app;
 
 bool HookFunction(PVOID* ppPointer, PVOID pDetour, const char* functionName) {
 	if (const auto error = DetourAttach(ppPointer, pDetour); error != NO_ERROR) {
@@ -140,6 +141,8 @@ void DetourInitilization() {
 	//HOOKFUNC(RoleManager_AssignRolesForTeam);
 	//HOOKFUNC(RoleManager_AssignRolesFromList);
 	HOOKFUNC(PlayerControl_HandleRpc);
+	HOOKFUNC(PlayerPhysics_HandleRpc);
+	HOOKFUNC(InnerNetClient_HandleGameData);
 	HOOKFUNC(PlayerControl_RpcStartMeeting);
 	HOOKFUNC(PlayerControl_CmdReportDeadBody);
 	HOOKFUNC(PlayerControl_RpcSendChat);
@@ -319,6 +322,8 @@ void DetourUninitialization()
 	//UNHOOKFUNC(RoleManager_AssignRolesForTeam);
 	//UNHOOKFUNC(RoleManager_AssignRolesFromList);
 	UNHOOKFUNC(PlayerControl_HandleRpc);
+	UNHOOKFUNC(PlayerPhysics_HandleRpc);
+	UNHOOKFUNC(InnerNetClient_HandleGameData);
 	UNHOOKFUNC(PlayerControl_RpcStartMeeting);
 	UNHOOKFUNC(PlayerControl_CmdReportDeadBody);
 	UNHOOKFUNC(PlayerControl_RpcSendChat);

--- a/hooks/_hooks.h
+++ b/hooks/_hooks.h
@@ -21,7 +21,7 @@ void dChatController_AddChat(ChatController* __this, PlayerControl* sourcePlayer
 void dChatController_SetVisible(ChatController* __this, bool visible, MethodInfo* method);
 void dGameStartManager_Update(GameStartManager* __this, MethodInfo* method);
 void dGameStartManager_ReallyBegin(GameStartManager* __this, bool neverShow, MethodInfo* method);
-void dHudManager_Update(HudManager* __this, MethodInfo* method);
+void dHudManager_Update(app::HudManager* __this, MethodInfo* method);
 Vector3 dCamera_ScreenToWorldPoint(Camera* __this, Vector3 position, MethodInfo* method);
 void dKeyboardJoystick_Update(KeyboardJoystick* __this, MethodInfo* method);
 void dScreenJoystick_FixedUpdate(ScreenJoystick* __this, MethodInfo* method);
@@ -88,7 +88,7 @@ void dInnerNetClient_DisconnectInternal(InnerNetClient* __this, DisconnectReason
 float dLogicOptions_GetKillDistance(LogicOptions* __this, MethodInfo* method);
 //TaskBarMode__Enum dLogicOptions_GetTaskBarMode(LogicOptions* __this, MethodInfo* method);
 void dGameManager_RpcEndGame(GameManager* __this, GameOverReason__Enum endReason, bool showAd, MethodInfo* method);
-void dRoleManager_SelectRoles(RoleManager* __this, MethodInfo* method);
+void dRoleManager_SelectRoles(app::RoleManager* __this, MethodInfo* method);
 //void dRoleManager_AssignRolesForTeam(List_1_GameData_PlayerInfo_* players, RoleOptionsData* opts, RoleTeamTypes__Enum team, int32_t teamMax, Nullable_1_RoleTypes_ defaultRole, MethodInfo* method);
 //void dRoleManager_AssignRolesFromList(List_1_GameData_PlayerInfo_* players, int32_t teamMax, List_1_RoleTypes_* roleList, int32_t* rolesAssigned, MethodInfo* method);
 void dPlayerPhysics_FixedUpdate(PlayerPhysics* __this, MethodInfo* method);
@@ -96,7 +96,7 @@ bool dSaveManager_GetPurchase(String* itemKey, String* bundleKey, MethodInfo* me
 void dPlayerControl_TurnOnProtection(PlayerControl* __this, bool visible, int32_t colorId, int32_t guardianPlayerId, MethodInfo* method);
 void dPlayerControl_RemoveProtection(PlayerControl* __this, MethodInfo* method);
 void dAmongUsClient_OnGameEnd(AmongUsClient* __this, EndGameResult* endGameResult, MethodInfo* method);
-void dAccountManager_UpdateKidAccountDisplay(AccountManager* __this, MethodInfo* method);
+void dAccountManager_UpdateKidAccountDisplay(app::AccountManager* __this, MethodInfo* method);
 void dPlayerStorageManager_OnReadPlayerPrefsComplete(PlayerStorageManager* __this, void* data, MethodInfo* method);
 bool dPlayerPurchasesData_GetPurchase(PlayerPurchasesData* __this, String* itemKey, String* bundleKey, MethodInfo* method);
 void dExileController_ReEnableGameplay(ExileController* __this, MethodInfo* method);
@@ -135,7 +135,7 @@ void dShipStatus_UpdateSystem(ShipStatus* __this, SystemTypes__Enum systemType, 
 void dPlayerControl_CmdCheckProtect(PlayerControl* __this, PlayerControl* target, MethodInfo* method);
 void dMeetingHud_RpcVotingComplete(MeetingHud* __this, MeetingHud_VoterState__Array* states, NetworkedPlayerInfo* exiled, bool tie, MethodInfo* method);
 void dMeetingHud_CheckForEndVoting(MeetingHud* __this, MethodInfo* method);
-bool dAccountManager_CanPlayOnline(AccountManager* __this, MethodInfo* method);
+bool dAccountManager_CanPlayOnline(app::AccountManager* __this, MethodInfo* method);
 bool dLogicOptions_GetAnonymousVotes(LogicOptions* __this, MethodInfo* method);
 //AsyncOperationHandle_1_UnityEngine_GameObject_ dAssetReference_InstantiateAsync_1(AssetReference* __this, Transform* parent, bool instantiateInWorldSpace, MethodInfo* method);
 bool dAprilFoolsMode_ShouldFlipSkeld(MethodInfo* method);
@@ -172,3 +172,8 @@ void* dPlayerControl_Start(PlayerControl* __this, MethodInfo* method);
 void dMainMenuManager_LateUpdate(MainMenuManager* __this, MethodInfo* method);
 AudioSource* dSoundManager_PlaySound(SoundManager* __this, AudioClip* clip, bool loop, float volume, AudioMixerGroup* audioMixer, MethodInfo* method);
 void dViperDeadBody_FixedUpdate(ViperDeadBody* __this, MethodInfo* method);
+void AntiOverload_OnPlayerJoin(uint8_t playerId);
+void AntiOverload_OnPlayerLeave(uint8_t playerId);
+void dPlayerPhysics_HandleRpc(PlayerPhysics* __this, uint8_t callId, MessageReader* reader, MethodInfo* method);
+void dInnerNetClient_HandleGameData(InnerNetClient* __this, MessageReader* parentReader, MethodInfo* method);
+bool RpcCheck(PlayerControl* player, uint8_t callId, int numData);

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -378,6 +378,7 @@ public:
     std::string versionShowerDefaultText = "";
 
     bool DisableHud = false;
+    bool AntiOverload = true;
     bool GodMode = false;
 
     bool ActiveAttach = false;


### PR DESCRIPTION
Anti Overload

What it does:

Blocks RPC spam floods per player with configurable rate limits
Blocks suspicious RPCs immediately
Blocks RPCs that shouldn't occur in lobby
Blocks data floods via HandleGameData byte threshold
Tracks players on join/leave with a 3-second grace period
Silent — no chat notifications, just drops the packets

Files changed:

hooks/AntiOverload.cpp — new file, core logic
hooks/_hooks.h — added declarations
hooks/_hooks.cpp — registered hooks
appdata/il2cpp-functions.h — added missing DO_APP_FUNC entries
hooks/InnerNetClient.cpp — call AntiOverload on player events
hooks/PlayerControl.cpp — integrated RpcCheck
user/state.hpp — added AntiOverload bool (default true)
gui/tabs/self_tab.cpp — added toggle button in Self tab