### PR TITLE
Fixed host arrows when changing a player role

### DIFF
--- a/gui/gui-helpers.cpp
+++ b/gui/gui-helpers.cpp
@@ -9,7 +9,7 @@
 
 using namespace ImGui;
 
-bool CustomListBoxInt(const char* label, int* value, const std::vector<const char*> list, float width, ImVec4 col, ImGuiComboFlags flags, const char* visualLabel) {
+bool CustomListBoxInt(const char* label, int* value, const std::vector<const char*> list, float width, ImVec4 col, ImGuiComboFlags flags, const char* visualLabel, const std::vector<int>& leftArrowCycle, const std::vector<int>& rightArrowCycle) {
 	auto comboLabel = "##" + std::string(label);
 	auto leftArrow = "##" + std::string(label) + "Left";
 	auto rightArrow = "##" + std::string(label) + "Right";
@@ -37,15 +37,29 @@ bool CustomListBoxInt(const char* label, int* value, const std::vector<const cha
 
 	const bool LeftResponse = ArrowButton(leftArrow.c_str(), ImGuiDir_Left);
 	if (LeftResponse) {
-		*value -= 1;
-		if (*value < 0) *value = int(list.size() - 1);
+		if (leftArrowCycle.empty()) {
+			*value -= 1;
+			if (*value < 0) *value = int(list.size() - 1);
+		}
+		else {
+			auto current = std::find(leftArrowCycle.begin(), leftArrowCycle.end(), *value);
+			size_t next = current == leftArrowCycle.end() ? 0 : (current - leftArrowCycle.begin() + 1) % leftArrowCycle.size();
+			*value = leftArrowCycle[next];
+		}
 		return LeftResponse;
 	}
 	SameLine(0, spacing);
 	const bool RightResponse = ArrowButton(rightArrow.c_str(), ImGuiDir_Right);
 	if (RightResponse) {
-		*value += 1;
-		if (*value > (int)(list.size() - 1)) *value = 0;
+		if (rightArrowCycle.empty()) {
+			*value += 1;
+			if (*value > (int)(list.size() - 1)) *value = 0;
+		}
+		else {
+			auto current = std::find(rightArrowCycle.begin(), rightArrowCycle.end(), *value);
+			size_t next = current == rightArrowCycle.end() ? 0 : (current - rightArrowCycle.begin() + 1) % rightArrowCycle.size();
+			*value = rightArrowCycle[next];
+		}
 		return RightResponse;
 	}
 	SameLine(0, spacing);
@@ -62,7 +76,7 @@ bool CustomListBoxInt(const char* label, int* value, const std::vector<const cha
 	return response;
 }
 
-bool CustomListBoxIntColored(const char* label, int* value, const std::vector<const char*> list, float width, ImVec4 col, ImGuiComboFlags flags, const char* visualLabel, const RoleColor* itemColors, size_t itemColorsCount)
+bool CustomListBoxIntColored(const char* label, int* value, const std::vector<const char*> list, float width, ImVec4 col, ImGuiComboFlags flags, const char* visualLabel, const RoleColor* itemColors, size_t itemColorsCount, const std::vector<int>& leftArrowCycle, const std::vector<int>& rightArrowCycle)
 {
 	auto comboLabel = "##" + std::string(label);
 	auto leftArrow = "##" + std::string(label) + "Left";
@@ -100,15 +114,29 @@ bool CustomListBoxIntColored(const char* label, int* value, const std::vector<co
 
 	const bool LeftResponse = ArrowButton(leftArrow.c_str(), ImGuiDir_Left);
 	if (LeftResponse) {
-		*value -= 1;
-		if (*value < 0) *value = int(list.size() - 1);
+		if (leftArrowCycle.empty()) {
+			*value -= 1;
+			if (*value < 0) *value = int(list.size() - 1);
+		}
+		else {
+			auto current = std::find(leftArrowCycle.begin(), leftArrowCycle.end(), *value);
+			size_t next = current == leftArrowCycle.end() ? 0 : (current - leftArrowCycle.begin() + 1) % leftArrowCycle.size();
+			*value = leftArrowCycle[next];
+		}
 		return LeftResponse;
 	}
 	SameLine(0, spacing);
 	const bool RightResponse = ArrowButton(rightArrow.c_str(), ImGuiDir_Right);
 	if (RightResponse) {
-		*value += 1;
-		if (*value > (int)(list.size() - 1)) *value = 0;
+		if (rightArrowCycle.empty()) {
+			*value += 1;
+			if (*value > (int)(list.size() - 1)) *value = 0;
+		}
+		else {
+			auto current = std::find(rightArrowCycle.begin(), rightArrowCycle.end(), *value);
+			size_t next = current == rightArrowCycle.end() ? 0 : (current - rightArrowCycle.begin() + 1) % rightArrowCycle.size();
+			*value = rightArrowCycle[next];
+		}
 		return RightResponse;
 	}
 	SameLine(0, spacing);

--- a/gui/gui-helpers.hpp
+++ b/gui/gui-helpers.hpp
@@ -13,8 +13,8 @@ static inline ImVec2 operator-(const ImVec2& lhs, const float scalar) { return I
 static inline ImVec2& operator+=(ImVec2& lhs, const float scalar) { lhs.x += scalar; lhs.y += scalar; return lhs; }
 static inline ImVec2& operator-=(ImVec2& lhs, const float scalar) { lhs.x -= scalar; lhs.y -= scalar; return lhs; }
 
-bool CustomListBoxInt(const char* label, int* value, const std::vector<const char*> list, float width = 225.f, ImVec4 col = ImVec4(0, 0, 0, 0), ImGuiComboFlags flags = ImGuiComboFlags_None, const char* visualLabel = "");
-bool CustomListBoxIntColored(const char* label, int* value, const std::vector<const char*> list, float width = 225.f, ImVec4 col = ImVec4(0, 0, 0, 0), ImGuiComboFlags flags = ImGuiComboFlags_None, const char* visualLabel = "", const RoleColor* itemColors = nullptr, size_t itemColorsCount = 0);
+bool CustomListBoxInt(const char* label, int* value, const std::vector<const char*> list, float width = 225.f, ImVec4 col = ImVec4(0, 0, 0, 0), ImGuiComboFlags flags = ImGuiComboFlags_None, const char* visualLabel = "", const std::vector<int>& leftArrowCycle = {}, const std::vector<int>& rightArrowCycle = {});
+bool CustomListBoxIntColored(const char* label, int* value, const std::vector<const char*> list, float width = 225.f, ImVec4 col = ImVec4(0, 0, 0, 0), ImGuiComboFlags flags = ImGuiComboFlags_None, const char* visualLabel = "", const RoleColor* itemColors = nullptr, size_t itemColorsCount = 0, const std::vector<int>& leftArrowCycle = {}, const std::vector<int>& rightArrowCycle = {});
 bool CustomListBoxIntMultiple(const char* label, std::vector<std::pair<const char*, bool>>* list, float width, bool resetButton = true, ImGuiComboFlags flags = ImGuiComboFlags_None);
 bool CustomListBoxPlayerSelectionMultiple(const char* label, std::array<std::pair<PlayerSelection, bool>, Game::MAX_PLAYERS>* list, float width, bool resetButton = true, ImGuiComboFlags flags = ImGuiComboFlags_None);
 bool SteppedSliderFloat(const char* label, float* v, float v_min, float v_max, float v_step, const char* format, ImGuiSliderFlags flags);

--- a/gui/tabs/host_tab.cpp
+++ b/gui/tabs/host_tab.cpp
@@ -193,8 +193,22 @@ namespace HostTab {
                                 {"Phantom",			State.PhantomColor},
                                 {"Viper",			State.ViperColor},
                             };
-                            if (CustomListBoxIntColored((playerName + "###" + ToString(playerData)).c_str(), reinterpret_cast<int*>(&State.assignedRoles[index]), ROLE_NAMES, 80 * State.dpiScale, AmongUsColorToImVec4(GetPlayerColor(outfit->fields.ColorId)), 0, RemoveHtmlTags(playerName).c_str(), ROLE_NAMES_COLOR, IM_ARRAYSIZE(ROLE_NAMES_COLOR)))
+                            static const std::vector<int> LEFT_ROLE_CYCLE = { 0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+                            static const std::vector<int> RIGHT_ROLE_CYCLE = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+                            static std::map<size_t, int> roleSelectorIndices;
+                            auto roleSelectorIt = roleSelectorIndices.find(index);
+                            if (roleSelectorIt == roleSelectorIndices.end())
+                                roleSelectorIt = roleSelectorIndices.emplace(index, (int)State.assignedRoles[index]).first;
+                            int& roleSelectorIndex = roleSelectorIt->second;
+                            static constexpr RoleType roles[] = {
+                                RoleType::Random, RoleType::Crewmate, RoleType::Scientist,
+                                RoleType::Engineer, RoleType::Noisemaker, RoleType::Tracker,
+                                RoleType::Detective, RoleType::Judge, RoleType::Impostor,
+                                RoleType::Shapeshifter, RoleType::Phantom, RoleType::Viper
+                            };
+                            if (CustomListBoxIntColored((playerName + "###" + ToString(playerData)).c_str(), &roleSelectorIndex, ROLE_NAMES, 80 * State.dpiScale, AmongUsColorToImVec4(GetPlayerColor(outfit->fields.ColorId)), 0, RemoveHtmlTags(playerName).c_str(), ROLE_NAMES_COLOR, IM_ARRAYSIZE(ROLE_NAMES_COLOR), LEFT_ROLE_CYCLE, RIGHT_ROLE_CYCLE))
                             {
+                                State.assignedRoles[index] = roles[std::clamp(roleSelectorIndex, 0, 11)];
                                 State.engineers_amount = (int)GetRoleCount(RoleType::Engineer);
                                 State.scientists_amount = (int)GetRoleCount(RoleType::Scientist);
                                 State.trackers_amount = (int)GetRoleCount(RoleType::Tracker);
@@ -319,25 +333,50 @@ namespace HostTab {
                             }
                         }
                         ImGui::SameLine();
-                        int hostRoleInt = (int)State.HostRoleToSet;
-                        if (CustomListBoxInt("###RoleSelector", &hostRoleInt, ROLE_NAMES, 80 * State.dpiScale, ImVec4(1.f, 1.f, 1.f, 0.f), 0, " ")) {
-                            if (State.HostRoleToSet == RoleType::Impostor || State.HostRoleToSet == RoleType::Shapeshifter || State.HostRoleToSet == RoleType::Phantom || State.HostRoleToSet == RoleType::Viper) {
-                                if (State.impostors_amount + State.shapeshifters_amount + State.phantoms_amount + State.vipers_amount + 1 > GetMaxImpostorAmount((int)GetAllPlayerData().size())) {
+                        static const std::vector<int> LEFT_ROLE_CYCLE = { 0, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1 };
+                        static const std::vector<int> RIGHT_ROLE_CYCLE = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11 };
+                        auto roleToListIndex = [](RoleType role) {
+                            switch (role) {
+                            case RoleType::Random:       return 0;
+                            case RoleType::Crewmate:     return 1;
+                            case RoleType::Scientist:    return 2;
+                            case RoleType::Engineer:     return 3;
+                            case RoleType::Noisemaker:   return 4;
+                            case RoleType::Tracker:      return 5;
+                            case RoleType::Detective:    return 6;
+                            case RoleType::Judge:        return 7;
+                            case RoleType::Impostor:     return 8;
+                            case RoleType::Shapeshifter: return 9;
+                            case RoleType::Phantom:      return 10;
+                            case RoleType::Viper:        return 11;
+                            default:                     return 0;
+                            }
+                        };
+                        static int hostRoleIndex = roleToListIndex(State.HostRoleToSet);
+                        if (CustomListBoxInt("###RoleSelector", &hostRoleIndex, ROLE_NAMES, 80 * State.dpiScale, ImVec4(1.f, 1.f, 1.f, 0.f), 0, " ", LEFT_ROLE_CYCLE, RIGHT_ROLE_CYCLE)) {
+                            static constexpr RoleType roles[] = {
+                                RoleType::Random, RoleType::Crewmate, RoleType::Scientist,
+                                RoleType::Engineer, RoleType::Noisemaker, RoleType::Tracker,
+                                RoleType::Detective, RoleType::Judge, RoleType::Impostor,
+                                RoleType::Shapeshifter, RoleType::Phantom, RoleType::Viper
+                            };
+                            State.HostRoleToSet = roles[std::clamp(hostRoleIndex, 0, 11)];
+                            if (State.HostRoleToSet == RoleType::Impostor ||
+                                State.HostRoleToSet == RoleType::Shapeshifter ||
+                                State.HostRoleToSet == RoleType::Phantom ||
+                                State.HostRoleToSet == RoleType::Viper) {
+                                if (State.impostors_amount + State.shapeshifters_amount +
+                                    State.phantoms_amount + State.vipers_amount + 1 >
+                                    GetMaxImpostorAmount((int)GetAllPlayerData().size())) {
                                     State.AutoHostRole = false;
                                 }
-                                else {
-                                    if (options.GetGameMode() == GameModes__Enum::HideNSeek) State.HostRoleToSet = RoleType::Impostor;
-                                }
                             }
-                            else {
-                                if (State.engineers_amount + State.scientists_amount + State.trackers_amount + State.noisemakers_amount + State.detectives_amount + State.judges_amount + State.crewmates_amount + 1 >= (int)GetAllPlayerData().size()) {
-                                    State.AutoHostRole = false;
-                                }
-                                else {
-                                    if (options.GetGameMode() == GameModes__Enum::HideNSeek) State.HostRoleToSet = RoleType::Engineer;
-                                }
+                            else if (State.engineers_amount + State.scientists_amount +
+                                     State.trackers_amount + State.noisemakers_amount +
+                                     State.detectives_amount + State.judges_amount +
+                                     State.crewmates_amount + 1 >= (int)GetAllPlayerData().size()) {
+                                State.AutoHostRole = false;
                             }
-                            State.HostRoleToSet = (RoleType)hostRoleInt;
                             State.Save();
                         }
                     }


### PR DESCRIPTION
okay so when you use the right arrow > it only shows Crewmate and then reset to to the default Random role it did not include (judge/Scientist/Engineer/Noisemaker.....etc) i fixed it and add the const definition so its gonna go on circle starting from 0 to 11 when using the right arrow. and from 11 to 0 when using the left arrow you can notice i used *value += 1 pointer value +1 the (rightArrow) and *value += 1 (for the leftArrow) so basically what will happen is that when you click the left arrow itll start from 11 and when using the right arrow itll start from 0 