### PR TITLE
Add: "Everyone" moderation role, /preset command, Chat Presets & more

### DIFF
--- a/gui/menu.cpp
+++ b/gui/menu.cpp
@@ -481,7 +481,7 @@ namespace Menu {
 			if (openEsp) EspTab::Render();
 			if (openPlayers) {
 				if (IsInGame() || IsInLobby()) PlayersTab::Render();
-				else {
+				else if (!State.VotekickRejoinPending && State.PendingRejoinTargetFC.empty()) {
 					CloseAllOtherTabs(Tabs::Game);
 					GameTab::Render();
 				}

--- a/gui/tabs/game_tab.cpp
+++ b/gui/tabs/game_tab.cpp
@@ -557,6 +557,13 @@ namespace GameTab {
                 ImGui::Dummy(ImVec2(0, 2) * State.dpiScale);
                 static std::string newChatPresetName = "MyPreset";
                 static int lastRenameIndex = -1;
+                auto chatPresetNameTaken = [](const std::string& name, int excludeIndex) {
+                    for (size_t i = 0; i < State.ChatPresets.size(); i++) {
+                        if ((int)i == excludeIndex) continue;
+                        if (State.ChatPresets[i].Name == name) return true;
+                    }
+                    return false;
+                    };
 
                 if (!State.ChatPresets.empty()) {
                     std::vector<const char*> presetNames;
@@ -604,13 +611,23 @@ namespace GameTab {
                 if (AnimatedButton("Save Current##chatpreset")) {
                     std::string sanitizedName = newChatPresetName;
                     sanitizedName.erase(std::remove(sanitizedName.begin(), sanitizedName.end(), ' '), sanitizedName.end());
-                    Settings::ChatPreset p;
-                    p.Name = sanitizedName.empty() ? "Preset" : sanitizedName;
-                    p.Messages = { State.chatMessage };
-                    State.ChatPresets.push_back(p);
-                    State.SelectedChatPreset = (int)State.ChatPresets.size() - 1;
-                    lastRenameIndex = State.SelectedChatPreset;
-                    State.Save();
+                    if (sanitizedName.empty()) sanitizedName = "Preset";
+                    if (chatPresetNameTaken(sanitizedName, -1)) {
+                        ImGui::OpenPopup("ChatPresetNameTaken");
+                    }
+                    else {
+                        Settings::ChatPreset p;
+                        p.Name = sanitizedName;
+                        p.Messages = { State.chatMessage };
+                        State.ChatPresets.push_back(p);
+                        State.SelectedChatPreset = (int)State.ChatPresets.size() - 1;
+                        lastRenameIndex = State.SelectedChatPreset;
+                        State.Save();
+                    }
+                }
+                if (ImGui::BeginPopup("ChatPresetNameTaken")) {
+                    ImGui::Text("A preset with that name already exists.");
+                    ImGui::EndPopup();
                 }
                 if (!State.ChatPresets.empty()) {
                     ImGui::SameLine();
@@ -618,8 +635,13 @@ namespace GameTab {
                         std::string sanitizedName = newChatPresetName;
                         sanitizedName.erase(std::remove(sanitizedName.begin(), sanitizedName.end(), ' '), sanitizedName.end());
                         if (!sanitizedName.empty()) {
-                            State.ChatPresets[State.SelectedChatPreset].Name = sanitizedName;
-                            State.Save();
+                            if (chatPresetNameTaken(sanitizedName, State.SelectedChatPreset)) {
+                                ImGui::OpenPopup("ChatPresetNameTaken");
+                            }
+                            else {
+                                State.ChatPresets[State.SelectedChatPreset].Name = sanitizedName;
+                                State.Save();
+                            }
                         }
                     }
                 }
@@ -673,21 +695,27 @@ namespace GameTab {
                     if (AnimatedButton("Combine as New Preset") && combineSelectionOrder.size() >= 2) {
                         std::string sanitizedName = combinedPresetName;
                         sanitizedName.erase(std::remove(sanitizedName.begin(), sanitizedName.end(), ' '), sanitizedName.end());
-                        Settings::ChatPreset combined;
-                        combined.Name = sanitizedName.empty() ? "CombinedPreset" : sanitizedName;
-                        combined.Messages.clear();
-                        for (int i : combineSelectionOrder) {
-                            if (i >= 0 && i < (int)combinableIndices.size()) {
-                                for (auto& m : State.ChatPresets[combinableIndices[i]].Messages) combined.Messages.push_back(m);
-                            }
+                        if (sanitizedName.empty()) sanitizedName = "CombinedPreset";
+                        if (chatPresetNameTaken(sanitizedName, -1)) {
+                            ImGui::OpenPopup("ChatPresetNameTaken");
                         }
-                        if (!combined.Messages.empty()) {
-                            State.ChatPresets.push_back(combined);
-                            State.SelectedChatPreset = (int)State.ChatPresets.size() - 1;
-                            combineList.clear(); 
-                            prevCombineChecked.clear();
-                            combineSelectionOrder.clear();
-                            State.Save();
+                        else {
+                            Settings::ChatPreset combined;
+                            combined.Name = sanitizedName;
+                            combined.Messages.clear();
+                            for (int i : combineSelectionOrder) {
+                                if (i >= 0 && i < (int)combinableIndices.size()) {
+                                    for (auto& m : State.ChatPresets[combinableIndices[i]].Messages) combined.Messages.push_back(m);
+                                }
+                            }
+                            if (!combined.Messages.empty()) {
+                                State.ChatPresets.push_back(combined);
+                                State.SelectedChatPreset = (int)State.ChatPresets.size() - 1;
+                                combineList.clear();
+                                prevCombineChecked.clear();
+                                combineSelectionOrder.clear();
+                                State.Save();
+                            }
                         }
                     }
                 }

--- a/gui/tabs/game_tab.cpp
+++ b/gui/tabs/game_tab.cpp
@@ -548,29 +548,149 @@ namespace GameTab {
                     { State.SafeMode ? "With Message (Self-Spam ONLY)" : "With Message", "Blank Chat", State.SafeMode ? "Self Message + Blank Chat" : "Message + Blank Chat" })) State.Save();
             }
 
-            if (std::find(State.ChatPresets.begin(), State.ChatPresets.end(), State.chatMessage) == State.ChatPresets.end() && AnimatedButton("Add Message as Preset")) {
-                State.ChatPresets.push_back(State.chatMessage);
-                State.Save();
-            }
             if (!(IsHost() || !State.SafeMode) && State.chatMessage.size() > 120) {
                 ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "Message will be detected by anticheat.");
             }
-            if (!State.ChatPresets.empty()) {
-                static int selectedPresetIndex = 0;
-                selectedPresetIndex = std::clamp(selectedPresetIndex, 0, (int)State.ChatPresets.size() - 1);
-                std::vector<const char*> presetVector(State.ChatPresets.size(), nullptr);
-                for (size_t i = 0; i < State.ChatPresets.size(); i++) {
-                    presetVector[i] = State.ChatPresets[i].c_str();
+
+            ImGui::Dummy(ImVec2(0, 4) * State.dpiScale);
+            if (ImGui::CollapsingHeader("Chat Presets", ImGuiTreeNodeFlags_DefaultOpen)) {
+                ImGui::Dummy(ImVec2(0, 2) * State.dpiScale);
+                static std::string newChatPresetName = "MyPreset";
+                static int lastRenameIndex = -1;
+
+                if (!State.ChatPresets.empty()) {
+                    std::vector<const char*> presetNames;
+                    for (auto& p : State.ChatPresets) presetNames.push_back(p.Name.c_str());
+                    State.SelectedChatPreset = std::clamp(State.SelectedChatPreset, 0, (int)State.ChatPresets.size() - 1);
+                    CustomListBoxInt("##chatpresetselect", &State.SelectedChatPreset, presetNames, 200.0f * State.dpiScale, ImVec4(0, 0, 0, 0), 0, "Preset");
+                    auto& selected = State.ChatPresets[State.SelectedChatPreset];
+
+                    if (lastRenameIndex != State.SelectedChatPreset) {
+                        newChatPresetName = selected.Name;
+                        lastRenameIndex = State.SelectedChatPreset;
+                    }
+
+                    ImGui::SameLine();
+                    if (AnimatedButton("Apply##chatpreset")) {
+                        State.chatMessage = selected.Messages.empty() ? "" : selected.Messages[0];
+                    }
+                    ImGui::SameLine();
+                    if (AnimatedButton("Update##chatpreset")) {
+                        selected.Messages = { State.chatMessage };
+                        State.Save();
+                    }
+                    ImGui::SameLine();
+                    if (AnimatedButton("Delete##chatpreset")) {
+                        State.ChatPresets.erase(State.ChatPresets.begin() + State.SelectedChatPreset);
+                        if (!State.ChatPresets.empty())
+                            State.SelectedChatPreset = std::clamp(State.SelectedChatPreset, 0, (int)State.ChatPresets.size() - 1);
+                        lastRenameIndex = -1;
+                        State.Save();
+                    }
                 }
-                CustomListBoxInt("Message to Send/Remove", &selectedPresetIndex, presetVector);
-                auto msg = State.ChatPresets[selectedPresetIndex];
-                if (AnimatedButton("Set as Chat Message"))
-                {
-                    State.chatMessage = msg;
+                else {
+                    ImGui::TextDisabled("No presets saved.");
                 }
+
+                ImGui::Dummy(ImVec2(0, 4) * State.dpiScale);
+
+                ImGui::SetNextItemWidth(160 * State.dpiScale);
+                InputString("##PresetNameInput", &newChatPresetName);
                 ImGui::SameLine();
-                if (AnimatedButton("Remove"))
-                    State.ChatPresets.erase(State.ChatPresets.begin() + selectedPresetIndex);
+                ImGui::TextUnformatted("Preset Name");
+                if (ImGui::IsItemHovered())
+                    ImGui::SetTooltip("Preset names can't contain spaces to be usable with /cmd (e.g. /rules).");
+                ImGui::SameLine();
+                if (AnimatedButton("Save Current##chatpreset")) {
+                    std::string sanitizedName = newChatPresetName;
+                    sanitizedName.erase(std::remove(sanitizedName.begin(), sanitizedName.end(), ' '), sanitizedName.end());
+                    Settings::ChatPreset p;
+                    p.Name = sanitizedName.empty() ? "Preset" : sanitizedName;
+                    p.Messages = { State.chatMessage };
+                    State.ChatPresets.push_back(p);
+                    State.SelectedChatPreset = (int)State.ChatPresets.size() - 1;
+                    lastRenameIndex = State.SelectedChatPreset;
+                    State.Save();
+                }
+                if (!State.ChatPresets.empty()) {
+                    ImGui::SameLine();
+                    if (AnimatedButton("Rename##chatpreset")) {
+                        std::string sanitizedName = newChatPresetName;
+                        sanitizedName.erase(std::remove(sanitizedName.begin(), sanitizedName.end(), ' '), sanitizedName.end());
+                        if (!sanitizedName.empty()) {
+                            State.ChatPresets[State.SelectedChatPreset].Name = sanitizedName;
+                            State.Save();
+                        }
+                    }
+                }
+
+                ImGui::Dummy(ImVec2(0, 4) * State.dpiScale);
+
+                // Only single message presets can be included, to prevent the already combined presets from piling up.
+                std::vector<int> combinableIndices;
+                for (int i = 0; i < (int)State.ChatPresets.size(); i++) {
+                    if (State.ChatPresets[i].Messages.size() <= 1) combinableIndices.push_back(i);
+                }
+
+                if (combinableIndices.size() >= 2 && ImGui::CollapsingHeader("Combine Presets")) {
+                    ImGui::Dummy(ImVec2(0, 2)* State.dpiScale);
+                    static std::vector<std::pair<const char*, bool>> combineList;
+                    static std::vector<std::string> combineNamesCache;
+                    static size_t lastCombinableCount = 0;
+                    static std::vector<bool> prevCombineChecked;
+                    static std::vector<int> combineSelectionOrder; // saves into combineList in the order the user checked them
+                    if (combineList.size() != combinableIndices.size()) {
+                        combineNamesCache.clear();
+                        for (int idx : combinableIndices) combineNamesCache.push_back(State.ChatPresets[idx].Name);
+                        combineList.clear();
+                        for (auto& n : combineNamesCache) combineList.push_back({ n.c_str(), false });
+                        lastCombinableCount = combinableIndices.size();
+                        prevCombineChecked.assign(combineList.size(), false);
+                        combineSelectionOrder.clear();
+                    }
+
+                    CustomListBoxIntMultiple("Presets to Combine", &combineList, 220.0f * State.dpiScale);
+
+                    if (prevCombineChecked.size() != combineList.size())
+                        prevCombineChecked.assign(combineList.size(), false);
+                    for (size_t i = 0; i < combineList.size(); i++) {
+                        bool nowChecked = combineList[i].second;
+                        bool wasChecked = prevCombineChecked[i];
+                        if (nowChecked && !wasChecked) {
+                            combineSelectionOrder.push_back((int)i);
+                        }
+                        else if (!nowChecked && wasChecked) {
+                            combineSelectionOrder.erase(std::remove(combineSelectionOrder.begin(), combineSelectionOrder.end(), (int)i), combineSelectionOrder.end());
+                        }
+                        prevCombineChecked[i] = nowChecked;
+                    }
+
+                    ImGui::Dummy(ImVec2(0, 4) * State.dpiScale);
+                    static std::string combinedPresetName = "CombinedPreset";
+                    ImGui::SetNextItemWidth(160 * State.dpiScale);
+                    InputString("Combined Preset Name", &combinedPresetName);
+                    ImGui::SameLine();
+                    if (AnimatedButton("Combine as New Preset") && combineSelectionOrder.size() >= 2) {
+                        std::string sanitizedName = combinedPresetName;
+                        sanitizedName.erase(std::remove(sanitizedName.begin(), sanitizedName.end(), ' '), sanitizedName.end());
+                        Settings::ChatPreset combined;
+                        combined.Name = sanitizedName.empty() ? "CombinedPreset" : sanitizedName;
+                        combined.Messages.clear();
+                        for (int i : combineSelectionOrder) {
+                            if (i >= 0 && i < (int)combinableIndices.size()) {
+                                for (auto& m : State.ChatPresets[combinableIndices[i]].Messages) combined.Messages.push_back(m);
+                            }
+                        }
+                        if (!combined.Messages.empty()) {
+                            State.ChatPresets.push_back(combined);
+                            State.SelectedChatPreset = (int)State.ChatPresets.size() - 1;
+                            combineList.clear(); 
+                            prevCombineChecked.clear();
+                            combineSelectionOrder.clear();
+                            State.Save();
+                        }
+                    }
+                }
             }
         }
 

--- a/gui/tabs/game_tab.cpp
+++ b/gui/tabs/game_tab.cpp
@@ -736,7 +736,7 @@ namespace GameTab {
                     "Setting Tasks", "Abnormal Murders", "Abnormal Shapeshift", "Abnormal Vanish",
                     "Abnormal Meetings/Body Reports", "Abnormal Venting", "Abnormal Chat",
                     "Abnormal Task Completion", "Abnormal Sabotages", "Abnormal Player Levels",
-                    "Abnormal Friendcode", "Blocked Words", "Blocked Start Words",
+                    "Abnormal Friendcode", "Blocked Words", "Blocked Start Words","Blacklisted Players",
                 };
                 static int selectedCategory = 0;
 

--- a/gui/tabs/game_tab.cpp
+++ b/gui/tabs/game_tab.cpp
@@ -721,9 +721,42 @@ namespace GameTab {
 
         if (openAnticheat) {
             if (ToggleButton("Enable Anticheat (SMAC)", &State.Enable_SMAC)) State.Save();
-            if (IsHost()) CustomListBoxInt("Host Punishment ", &State.SMAC_HostPunishment, SMAC_HOST_PUNISHMENTS, 85.0f * State.dpiScale);
-            else CustomListBoxInt("Regular Punishment", &State.SMAC_Punishment, SMAC_PUNISHMENTS, 85.0f * State.dpiScale);
+            ImGui::Dummy(ImVec2(0, 1)* State.dpiScale);
+            if (ImGui::CollapsingHeader("Action on Detection##smacoverride")) {
+                ImGui::TextDisabled("Default action taken when a detection isn't specifically overridden below.");
+                if (IsHost()) CustomListBoxInt("Host Punishment ", &State.SMAC_HostPunishment, SMAC_HOST_PUNISHMENTS, 85.0f * State.dpiScale);
+                else CustomListBoxInt("Regular Punishment", &State.SMAC_Punishment, SMAC_PUNISHMENTS, 85.0f * State.dpiScale);
 
+                ImGui::Dummy(ImVec2(0, 1) * State.dpiScale);
+                ImGui::TextDisabled("Override the action for a specific detection.");
+
+                static const std::vector<const char*> SMAC_CATEGORIES = {
+                    "Known Cheat Usage", "SickoMenu Usage", "Abnormal Names", "Abnormal Set Color",
+                    "Abnormal Set Cosmetics", "Abnormal Chat Note", "Abnormal Scanner", "Abnormal Animation",
+                    "Setting Tasks", "Abnormal Murders", "Abnormal Shapeshift", "Abnormal Vanish",
+                    "Abnormal Meetings/Body Reports", "Abnormal Venting", "Abnormal Chat",
+                    "Abnormal Task Completion", "Abnormal Sabotages", "Abnormal Player Levels",
+                    "Abnormal Friendcode", "Blocked Words", "Blocked Start Words",
+                };
+                static int selectedCategory = 0;
+
+                std::string catKey = SMAC_CATEGORIES[selectedCategory];
+                auto& overrides = State.SMAC_ReasonPunishmentOverride;
+                if (overrides.find(catKey) == overrides.end())
+                    overrides[catKey] = IsHost() ? State.SMAC_HostPunishment : State.SMAC_Punishment;
+                int currentMaxIndex = IsHost() ? (int)SMAC_HOST_PUNISHMENTS.size() - 1 : (int)SMAC_PUNISHMENTS.size() - 1;
+                overrides[catKey] = std::clamp(overrides[catKey], 0, currentMaxIndex);
+
+                ImGui::SetNextItemWidth(150.0f * State.dpiScale);
+                CustomListBoxInt("Category", &selectedCategory, SMAC_CATEGORIES, 150.0f * State.dpiScale);
+                ImGui::SameLine();
+
+                bool changed;
+                if (IsHost()) changed = CustomListBoxInt("Punishment##smacoverridelevel", &overrides[catKey], SMAC_HOST_PUNISHMENTS, 85.0f * State.dpiScale);
+                else changed = CustomListBoxInt("Punishment##smacoverridelevel", &overrides[catKey], SMAC_PUNISHMENTS, 85.0f * State.dpiScale);
+                if (changed) State.Save();
+            }
+            ImGui::Dummy(ImVec2(0, 2)* State.dpiScale);
             if (ToggleButton("Add Cheaters to Blacklist", &State.SMAC_AddToBlacklist)) State.Save();
             ImGui::SameLine();
             if (ToggleButton("Punish Blacklist", &State.SMAC_PunishBlacklist)) State.Save();
@@ -842,24 +875,38 @@ namespace GameTab {
             }
             if (ToggleButton("Blocked Words", &State.SMAC_CheckBadWords)) State.Save();
             if (State.SMAC_CheckBadWords) {
+                static const std::vector<const char*> SMAC_DETECTION_MODES = { "Default Detection", "Strict Detection" };
                 if (State.SMAC_BadWords.empty())
                     ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "No bad words added!");
                 static std::string newWord = "";
                 InputString("New Word", &newWord, ImGuiInputTextFlags_EnterReturnsTrue);
                 ImGui::SameLine();
                 if (AnimatedButton("Add Word")) {
-                    State.SMAC_BadWords.push_back(newWord);
-                    State.Save();
-                    newWord = "";
+                    std::string newWordLower = strToLower(newWord);
+                    bool alreadyExists = std::any_of(State.SMAC_BadWords.begin(), State.SMAC_BadWords.end(),
+                        [&](auto& w) { return strToLower(w.first) == newWordLower; });
+                    if (!newWord.empty() && !alreadyExists) {
+                        State.SMAC_BadWords.push_back({ newWord, false });
+                        State.Save();
+                        newWord = "";
+                    }
                 }
                 if (!State.SMAC_BadWords.empty()) {
                     static int selectedWordIndex = 0;
                     selectedWordIndex = std::clamp(selectedWordIndex, 0, (int)State.SMAC_BadWords.size() - 1);
-                    std::vector<const char*> wordVector(State.SMAC_BadWords.size(), nullptr);
-                    for (size_t i = 0; i < State.SMAC_BadWords.size(); i++) {
-                        wordVector[i] = State.SMAC_BadWords[i].c_str();
-                    }
+                    std::vector<std::string> wordDisplayStrings;
+                    for (auto& w : State.SMAC_BadWords)
+                        wordDisplayStrings.push_back(w.first + (w.second ? " [Strict]" : " [Default]"));
+                    std::vector<const char*> wordVector(wordDisplayStrings.size(), nullptr);
+                    for (size_t i = 0; i < wordDisplayStrings.size(); i++)
+                        wordVector[i] = wordDisplayStrings[i].c_str();
                     CustomListBoxInt("Word to Remove", &selectedWordIndex, wordVector);
+                    ImGui::SameLine();
+                    int badWordMode = State.SMAC_BadWords[selectedWordIndex].second ? 1 : 0;
+                    if (CustomListBoxInt("Detection Mode##badwords", &badWordMode, SMAC_DETECTION_MODES, 130.0f * State.dpiScale)) {
+                        State.SMAC_BadWords[selectedWordIndex].second = (badWordMode == 1);
+                        State.Save();
+                    }
                     ImGui::SameLine();
                     if (AnimatedButton("Remove"))
                         State.SMAC_BadWords.erase(State.SMAC_BadWords.begin() + selectedWordIndex);
@@ -868,12 +915,10 @@ namespace GameTab {
 
             if (ToggleButton("Blocked Start Words", &State.SMAC_CheckStartWords)) State.Save();
             if (State.SMAC_CheckStartWords) {
-                ImGui::SameLine();
-                if (ToggleButton("Strict Detection", &State.SMAC_StartWordsStrict)) State.Save();
-                ImGui::SameLine();
-                ImGui::SetNextItemWidth(80.0f * State.dpiScale);
+                static const std::vector<const char*> SMAC_DETECTION_MODES = { "Default Detection", "Strict Detection" };
+                ImGui::SetNextItemWidth(70.0f * State.dpiScale);
                 if (ImGui::InputInt("Violations Before Action", &State.SMAC_StartWordsThreshold)) {
-                    if (State.SMAC_StartWordsThreshold < 1) State.SMAC_StartWordsThreshold = 1;
+                    State.SMAC_StartWordsThreshold = std::clamp(State.SMAC_StartWordsThreshold, 1, 10);
                     State.Save();
                 }
                 if (State.SMAC_StartWords.empty())
@@ -882,18 +927,31 @@ namespace GameTab {
                 InputString("New W\u043Erd", &newStartWord, ImGuiInputTextFlags_EnterReturnsTrue);
                 ImGui::SameLine();
                 if (AnimatedButton("Add Word##StartWord")) {
-                    State.SMAC_StartWords.push_back(newStartWord);
-                    State.Save();
-                    newStartWord = "";
+                    std::string newStartWordLower = strToLower(newStartWord);
+                    bool alreadyExists = std::any_of(State.SMAC_StartWords.begin(), State.SMAC_StartWords.end(),
+                        [&](auto& w) { return strToLower(w.first) == newStartWordLower; });
+                    if (!newStartWord.empty() && !alreadyExists) {
+                        State.SMAC_StartWords.push_back({ newStartWord, false });
+                        State.Save();
+                        newStartWord = "";
+                    }
                 }
                 if (!State.SMAC_StartWords.empty()) {
                     static int selectedStartWordIndex = 0;
                     selectedStartWordIndex = std::clamp(selectedStartWordIndex, 0, (int)State.SMAC_StartWords.size() - 1);
-                    std::vector<const char*> startWordVector(State.SMAC_StartWords.size(), nullptr);
-                    for (size_t i = 0; i < State.SMAC_StartWords.size(); i++) {
-                        startWordVector[i] = State.SMAC_StartWords[i].c_str();
-                    }
+                    std::vector<std::string> startWordDisplayStrings;
+                    for (auto& w : State.SMAC_StartWords)
+                        startWordDisplayStrings.push_back(w.first + (w.second ? " [Strict]" : " [Default]"));
+                    std::vector<const char*> startWordVector(startWordDisplayStrings.size(), nullptr);
+                    for (size_t i = 0; i < startWordDisplayStrings.size(); i++)
+                        startWordVector[i] = startWordDisplayStrings[i].c_str();
                     CustomListBoxInt("Start Word to Remove", &selectedStartWordIndex, startWordVector);
+                    ImGui::SameLine();
+                    int startWordMode = State.SMAC_StartWords[selectedStartWordIndex].second ? 1 : 0;
+                    if (CustomListBoxInt("Detection Mode##startwords", &startWordMode, SMAC_DETECTION_MODES, 130.0f * State.dpiScale)) {
+                        State.SMAC_StartWords[selectedStartWordIndex].second = (startWordMode == 1);
+                        State.Save();
+                    }
                     ImGui::SameLine();
                     if (AnimatedButton("Remove##StartWord")) {
                         State.SMAC_StartWords.erase(State.SMAC_StartWords.begin() + selectedStartWordIndex);

--- a/gui/tabs/host_tab.cpp
+++ b/gui/tabs/host_tab.cpp
@@ -966,7 +966,7 @@ namespace HostTab {
                             State.Mod_RoleNames.push_back(newRoleName);
                             State.Mod_RoleMembers.push_back({});
                             State.Mod_RolePermissions.push_back({});
-                            State.Mod_RoleRank.push_back(0);
+                            State.Mod_RoleRank.push_back(1); 
                             selectedRole = (int)State.Mod_RoleNames.size() - 1;
                             newRoleName = "";
                             State.Save();
@@ -1057,21 +1057,8 @@ namespace HostTab {
                                 ImGui::SameLine();
                                 if (AnimatedButton("Add (friendcode)##RoleMember")) {
                                     if (!newMemberCode.empty()) {
-                                        State.Mod_RoleMembers[selectedRole].push_back(newMemberCode);
+                                        SetFriendCodeInRole(newMemberCode, selectedRole, true); 
                                         newMemberCode = "";
-                                        State.Save();
-                                    }
-                                }
-                                auto& members = State.Mod_RoleMembers[selectedRole];
-                                if (!members.empty()) {
-                                    selectedMemberIndex = std::clamp(selectedMemberIndex, 0, (int)members.size() - 1);
-                                    std::vector<const char*> memberVector(members.size(), nullptr);
-                                    for (size_t i = 0; i < members.size(); i++) memberVector[i] = members[i].c_str();
-                                    CustomListBoxInt("##RemoveRoleMember", &selectedMemberIndex, memberVector, 150.0f * State.dpiScale, ImVec4(0, 0, 0, 0), ImGuiComboFlags_None, " ");
-                                    ImGui::SameLine();
-                                    if (AnimatedButton("Remove##RoleMember")) {
-                                        members.erase(members.begin() + selectedMemberIndex);
-                                        State.Save();
                                     }
                                 }
                             }

--- a/gui/tabs/host_tab.cpp
+++ b/gui/tabs/host_tab.cpp
@@ -917,10 +917,10 @@ namespace HostTab {
                 if (ImGui::CollapsingHeader("Roles", ImGuiTreeNodeFlags_DefaultOpen)) {
                     ImGui::Dummy(ImVec2(0, 2) * State.dpiScale);
                     static const std::vector<std::pair<const char*, const char*>> ROLE_COMMANDS = {
-                        { "/color", "color" }, { "/rules", "r" },
-                        { "/sicko", "sicko" }, { "/warn & /unwarn", "warn" },
-                        { "/kick & /kickc", "kick" }, { "/ban & /banc", "ban" },
-                        { "/callmeeting", "callmeeting" }, { "/endmeeting", "endmeeting" }, { "/start", "start" }, { "/end", "end" },
+        { "/color", "color" }, { "/preset", "preset" },
+    { "/sicko", "sicko" }, { "/warn & /unwarn", "warn" },
+    { "/kick & /kickc", "kick" }, { "/ban & /banc", "ban" },
+    { "/callmeeting", "callmeeting" }, { "/endmeeting", "endmeeting" }, { "/start", "start" }, { "/end", "end" },
                     };
                     static int selectedRole = 0;
                     static std::string newRoleName = "";
@@ -950,6 +950,8 @@ namespace HostTab {
                     ImGui::Dummy(ImVec2(0, 4) * State.dpiScale);
 
                     if (State.Mod_RoleRank.size() < State.Mod_RoleNames.size()) State.Mod_RoleRank.resize(State.Mod_RoleNames.size(), 0);
+                    if (State.Mod_RoleMembers.size() < State.Mod_RoleNames.size()) State.Mod_RoleMembers.resize(State.Mod_RoleNames.size());
+                    if (State.Mod_RolePermissions.size() < State.Mod_RoleNames.size()) State.Mod_RolePermissions.resize(State.Mod_RoleNames.size());
 
                     if (!State.Mod_RoleNames.empty()) {
                         selectedRole = std::clamp(selectedRole, 0, (int)State.Mod_RoleNames.size() - 1);
@@ -958,12 +960,16 @@ namespace HostTab {
                         ImGui::Text("Select Role:");
                         ImGui::SameLine();
                         CustomListBoxInt("SelectedRole", &selectedRole, roleVector, 150.0f * State.dpiScale, ImVec4(0, 0, 0, 0), ImGuiComboFlags_None, " ");
-                        ImGui::SameLine();
-                        ImGui::SetNextItemWidth(60.0f * State.dpiScale);
-                        ImGui::InputInt("##EditRoleRank", &State.Mod_RoleRank[selectedRole]);
-                        ImGui::SameLine();
-                        if (AnimatedButton("Set Rank")) {
-                            State.Save();
+                        if (selectedRole != 0) {
+                            ImGui::SameLine();
+                            ImGui::SetNextItemWidth(60.0f * State.dpiScale);
+                            if (ImGui::InputInt("##EditRoleRank", &State.Mod_RoleRank[selectedRole])) {
+                                if (State.Mod_RoleRank[selectedRole] < 0) State.Mod_RoleRank[selectedRole] = 0;
+                            }
+                            ImGui::SameLine();
+                            if (AnimatedButton("Set Rank")) {
+                                State.Save();
+                            }
                         }
                     }
                     else {
@@ -982,14 +988,16 @@ namespace HostTab {
                                 State.Save();
                             }
                         }
-                        ImGui::SameLine();
-                        if (AnimatedButton("Delete Role")) {
-                            State.Mod_RoleNames.erase(State.Mod_RoleNames.begin() + selectedRole);
-                            State.Mod_RoleMembers.erase(State.Mod_RoleMembers.begin() + selectedRole);
-                            State.Mod_RolePermissions.erase(State.Mod_RolePermissions.begin() + selectedRole);
-                            State.Mod_RoleRank.erase(State.Mod_RoleRank.begin() + selectedRole);
-                            State.Save();
-                            isRoleDeleted = true;
+                        if (selectedRole != 0) {
+                            ImGui::SameLine();
+                            if (AnimatedButton("Delete Role")) {
+                                State.Mod_RoleNames.erase(State.Mod_RoleNames.begin() + selectedRole);
+                                State.Mod_RoleMembers.erase(State.Mod_RoleMembers.begin() + selectedRole);
+                                State.Mod_RolePermissions.erase(State.Mod_RolePermissions.begin() + selectedRole);
+                                State.Mod_RoleRank.erase(State.Mod_RoleRank.begin() + selectedRole);
+                                State.Save();
+                                isRoleDeleted = true;
+                            }
                         }
 
                         if (!isRoleDeleted) {
@@ -1012,17 +1020,33 @@ namespace HostTab {
                                 ImGui::NextColumn();
                             }
                             ImGui::Columns(1);
-
                             ImGui::Dummy(ImVec2(0, 6) * State.dpiScale);
-                            ImGui::Text("Members:");
-                            ImGui::SetNextItemWidth(150.0f * State.dpiScale);
-                            InputString("##NewMemberCode", &newMemberCode, ImGuiInputTextFlags_EnterReturnsTrue);
-                            ImGui::SameLine();
-                            if (AnimatedButton("Add (friendcode)##RoleMember")) {
-                                if (!newMemberCode.empty()) {
-                                    State.Mod_RoleMembers[selectedRole].push_back(newMemberCode);
-                                    newMemberCode = "";
-                                    State.Save();
+                            if (selectedRole == 0) {
+                                ImGui::TextDisabled("Applies to every player automatically - no members needed.");
+                            }
+                            else {
+                                ImGui::Text("Members:");
+                                ImGui::SetNextItemWidth(150.0f * State.dpiScale);
+                                InputString("##NewMemberCode", &newMemberCode, ImGuiInputTextFlags_EnterReturnsTrue);
+                                ImGui::SameLine();
+                                if (AnimatedButton("Add (friendcode)##RoleMember")) {
+                                    if (!newMemberCode.empty()) {
+                                        State.Mod_RoleMembers[selectedRole].push_back(newMemberCode);
+                                        newMemberCode = "";
+                                        State.Save();
+                                    }
+                                }
+                                auto& members = State.Mod_RoleMembers[selectedRole];
+                                if (!members.empty()) {
+                                    selectedMemberIndex = std::clamp(selectedMemberIndex, 0, (int)members.size() - 1);
+                                    std::vector<const char*> memberVector(members.size(), nullptr);
+                                    for (size_t i = 0; i < members.size(); i++) memberVector[i] = members[i].c_str();
+                                    CustomListBoxInt("##RemoveRoleMember", &selectedMemberIndex, memberVector, 150.0f * State.dpiScale, ImVec4(0, 0, 0, 0), ImGuiComboFlags_None, " ");
+                                    ImGui::SameLine();
+                                    if (AnimatedButton("Remove##RoleMember")) {
+                                        members.erase(members.begin() + selectedMemberIndex);
+                                        State.Save();
+                                    }
                                 }
                             }
                             auto& members = State.Mod_RoleMembers[selectedRole];

--- a/gui/tabs/players_tab.cpp
+++ b/gui/tabs/players_tab.cpp
@@ -135,6 +135,23 @@ namespace PlayersTab {
                 State.selectedPlayer = {};
             }
 
+            if (!State.PendingRejoinTargetFC.empty() && State.PendingRejoinReady) {
+                for (auto pc : GetAllPlayerControl()) {
+                    if (pc == nullptr) continue;
+                    auto pd = GetPlayerData(pc);
+                    if (pd == nullptr || pd->fields.Disconnected) continue;
+                    std::string fc = convert_from_string(pd->fields.FriendCode);
+                    std::string name = convert_from_string(NetworkedPlayerInfo_get_PlayerName(pd, nullptr));
+                    if (fc == State.PendingRejoinTargetFC || name == State.PendingRejoinTargetFC) {
+                        State.selectedPlayer = PlayerSelection(pc);
+                        State.selectedPlayers = { pd->fields.PlayerId };
+                        State.PendingRejoinTargetFC = "";
+                        State.PendingRejoinReady = false;
+                        break;
+                    }
+                }
+            }
+
             auto selectedPlayer = State.selectedPlayer.validate();
             bool shouldEndListBox = ImGui::ListBoxHeader("###players#list", ImVec2(200, 230) * State.dpiScale);
             auto localData = GetPlayerData(*Game::pLocalPlayer);

--- a/gui/tabs/players_tab.cpp
+++ b/gui/tabs/players_tab.cpp
@@ -1742,21 +1742,22 @@ namespace PlayersTab {
                     if (targetFC.empty()) {
                         ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "No friend code available for this player.");
                     }
-                    else if (State.Mod_RoleNames.empty()) {
+                    else if (State.Mod_RoleNames.size() <= 1) { 
                         ImGui::TextDisabled("No roles created yet - add some in the Host tab.");
                     }
                     else {
-                        static int addRoleIndex = 0;
-                        addRoleIndex = std::clamp(addRoleIndex, 0, (int)State.Mod_RoleNames.size() - 1);
-                        std::vector<const char*> roleVector(State.Mod_RoleNames.size(), nullptr);
-                        for (size_t i = 0; i < State.Mod_RoleNames.size(); i++) roleVector[i] = State.Mod_RoleNames[i].c_str();
+                        static int addRoleIndex = 0; // index into the assignable roles only (excludes "Everyone")
+                        int assignableCount = (int)State.Mod_RoleNames.size() - 1;
+                        addRoleIndex = std::clamp(addRoleIndex, 0, assignableCount - 1);
+                        std::vector<const char*> roleVector(assignableCount, nullptr);
+                        for (int i = 0; i < assignableCount; i++) roleVector[i] = State.Mod_RoleNames[i + 1].c_str();
 
                         ImGui::Text("Add Role:");
                         ImGui::SameLine();
                         CustomListBoxInt("AddPlayerRole", &addRoleIndex, roleVector, 130.0f * State.dpiScale, ImVec4(0, 0, 0, 0), ImGuiComboFlags_None, " ");
                         ImGui::SameLine();
                         if (AnimatedButton("Add##PlayerRole")) {
-                            SetFriendCodeInRole(targetFC, addRoleIndex, true);
+                            SetFriendCodeInRole(targetFC, addRoleIndex + 1, true);
                         }
 
                         auto currentRoles = GetFriendCodeRoleIndices(targetFC);

--- a/gui/tabs/self_tab.cpp
+++ b/gui/tabs/self_tab.cpp
@@ -660,6 +660,10 @@ namespace SelfTab {
                 State.Save();
             }
             ImGui::SameLine();
+            if (ToggleButton("Auto-Rejoin on Votekick", &State.AutoRejoinOnKick)) {
+                State.Save();
+            }
+
             if (ToggleButton("Disable Shush Animation", &State.DisableShushAnimation)) {
                 State.Save();
             }

--- a/hooks/Chat.cpp
+++ b/hooks/Chat.cpp
@@ -613,10 +613,31 @@ void dChatController_AddChat(ChatController* __this, PlayerControl* sourcePlayer
 			}
 			if (State.SMAC_CheckBadWords) {
 				std::string lowerMessage = strToLower(message);
-				for (auto word : State.SMAC_BadWords) {
-					std::string lowerWord = strToLower(word);
-					if (lowerMessage.find(lowerWord) != std::string::npos) {
-						SMAC_OnCheatDetected(sourcePlayer, "Bad Word: " + word);
+				std::string firstWordBad = lowerMessage.substr(0, lowerMessage.find(' '));
+				for (auto& wordEntry : State.SMAC_BadWords) {
+					std::string lowerWord = strToLower(wordEntry.first);
+					if (lowerWord.empty()) continue;
+					bool matched = wordEntry.second ? (lowerMessage.find(lowerWord) != std::string::npos) : (firstWordBad == lowerWord);
+					if (matched) {
+						SMAC_OnCheatDetected(sourcePlayer, "Bad Word: " + wordEntry.first);
+						break;
+					}
+				}
+			}
+
+			if (State.SMAC_CheckStartWords && !IsInGame()) {
+				std::string lowerMessage = strToLower(message);
+				std::string firstWordStart = lowerMessage.substr(0, lowerMessage.find(' '));
+				uint8_t chatterId = sourcePlayer->fields.PlayerId;
+				for (auto& wordEntry : State.SMAC_StartWords) {
+					std::string lowerWord = strToLower(wordEntry.first);
+					if (lowerWord.empty()) continue;
+					bool matched = wordEntry.second ? (lowerMessage.find(lowerWord) != std::string::npos) : (firstWordStart == lowerWord);
+					if (matched) {
+						if (++State.SMAC_StartWordsCount[chatterId] >= State.SMAC_StartWordsThreshold) {
+							SMAC_OnCheatDetected(sourcePlayer, "Start Word: " + wordEntry.first);
+							State.SMAC_StartWordsCount[chatterId] = 0;
+						}
 						break;
 					}
 				}

--- a/hooks/Chat.cpp
+++ b/hooks/Chat.cpp
@@ -299,6 +299,9 @@ void ShowChatNotification(ChatNotification* chatNotification, PlayerControl* sen
 
 static const std::string SICKO_SOCIALS_MESSAGE = "Check out SickoMenu!\n\nGitHub: github.com/g0aty/SickoMenu\nDisc\u043Erd: Disc\u043Erd.gg/sickos";
 
+// GetCurrentGameModeName / BuildGameRulesMessages are on hold until more gamemodes are added back -
+// /preset (below) replaces this system in the meantime, driven by user-saved presets instead of hardcoded rules.
+/*
 static std::string GetCurrentGameModeName() {
 	std::vector<std::string> GAMEMODES = State.DisableHostAnticheat
 		? std::vector<std::string>{ "Default", "Task Speedrun", "Battle Royale" }
@@ -316,6 +319,22 @@ static std::vector<std::string> BuildGameRulesMessages(const std::string& modeNa
 	}
 	return {};
 }
+*/
+
+static void SendChatPreset(const Settings::ChatPreset& preset) {
+	if (preset.Messages.empty()) return;
+	PlayerControl_RpcSendChat(*Game::pLocalPlayer, convert_to_string(preset.Messages.front()), NULL);
+	State.Mod_PendingRulesMessages = {};
+	for (size_t i = 1; i < preset.Messages.size(); i++) State.Mod_PendingRulesMessages.push(preset.Messages[i]);
+	State.Mod_PendingRulesDelay = 2.0f;
+}
+
+static const Settings::ChatPreset* FindChatPresetByName(const std::string& lowerName) {
+	for (auto& p : State.ChatPresets) {
+		if (strToLower(p.Name) == lowerName) return &p;
+	}
+	return nullptr;
+}
 
 static bool HandleChatCommand(PlayerControl* actor, const std::string& message) {
 	if (!State.Mod_EnableModeration) return false;
@@ -329,13 +348,22 @@ static bool HandleChatCommand(PlayerControl* actor, const std::string& message) 
 	std::string argsLower = strToLower(rawArgs);
 
 	if (cmd == "/s") cmd = "/start";
-	if (cmd == "/rules") cmd = "/r";
 	if (cmd == "/w") cmd = "/warn";
 	if (cmd == "/uw") cmd = "/unwarn";
 	if (cmd == "/cw") cmd = "/checkwarns";
 
+
+	if (cmd != "/preset") {
+		std::string shorthandName = cmd.substr(1); // strip leading '/'
+		const Settings::ChatPreset* shorthandPreset = FindChatPresetByName(shorthandName);
+		if (shorthandPreset != nullptr) {
+			if (PlayerHasPermission(actor, "preset")) SendChatPreset(*shorthandPreset);
+			return true;
+		}
+	}
+
 	static const std::set<std::string> KNOWN_COMMANDS = {
-		"/color", "/colour", "/r", "/sicko",
+		"/color", "/colour", "/preset", "/sicko",
 		"/kick", "/kickc", "/ban", "/banc",
 		"/warn", "/warnc", "/unwarn", "/unwarnc", "/checkwarns",
 		"/callmeeting", "/endmeeting", "/start", "/end",
@@ -363,15 +391,10 @@ static bool HandleChatCommand(PlayerControl* actor, const std::string& message) 
 			PlayerControl_RpcSendChat(*Game::pLocalPlayer, convert_to_string(sickoText), NULL);
 		}
 	}
-	else if (cmd == "/r") {
-		if (PlayerHasPermission(actor, "r")) {
-			auto rulesMessages = BuildGameRulesMessages(GetCurrentGameModeName());
-			if (!rulesMessages.empty()) {
-				PlayerControl_RpcSendChat(*Game::pLocalPlayer, convert_to_string(rulesMessages.front()), NULL);
-				State.Mod_PendingRulesMessages = {};
-				for (size_t i = 1; i < rulesMessages.size(); i++) State.Mod_PendingRulesMessages.push(rulesMessages[i]);
-				State.Mod_PendingRulesDelay = 2.0f;
-			}
+	else if (cmd == "/preset") {
+		if (PlayerHasPermission(actor, "preset") && !rawArgs.empty()) {
+			const Settings::ChatPreset* preset = FindChatPresetByName(argsLower);
+			if (preset != nullptr) SendChatPreset(*preset);
 		}
 	}
 	else if (cmd == "/kick" || cmd == "/kickc" || cmd == "/ban" || cmd == "/banc") {

--- a/hooks/Chat.cpp
+++ b/hooks/Chat.cpp
@@ -353,7 +353,14 @@ static bool HandleChatCommand(PlayerControl* actor, const std::string& message) 
 	if (cmd == "/cw") cmd = "/checkwarns";
 
 
-	if (cmd != "/preset") {
+	static const std::set<std::string> KNOWN_COMMANDS = {
+	"/color", "/colour", "/preset", "/sicko",
+	"/kick", "/kickc", "/ban", "/banc",
+	"/warn", "/warnc", "/unwarn", "/unwarnc", "/checkwarns",
+	"/callmeeting", "/endmeeting", "/start", "/end",
+	};
+
+	if (!KNOWN_COMMANDS.count(cmd) && cmd != "/preset") {
 		std::string shorthandName = cmd.substr(1); // strip leading '/'
 		const Settings::ChatPreset* shorthandPreset = FindChatPresetByName(shorthandName);
 		if (shorthandPreset != nullptr) {
@@ -362,12 +369,6 @@ static bool HandleChatCommand(PlayerControl* actor, const std::string& message) 
 		}
 	}
 
-	static const std::set<std::string> KNOWN_COMMANDS = {
-		"/color", "/colour", "/preset", "/sicko",
-		"/kick", "/kickc", "/ban", "/banc",
-		"/warn", "/warnc", "/unwarn", "/unwarnc", "/checkwarns",
-		"/callmeeting", "/endmeeting", "/start", "/end",
-	};
 	if (!KNOWN_COMMANDS.count(cmd)) return false;
 
 	auto localWarn = [&](const std::string& text) {

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -407,6 +407,15 @@ void dInnerNetClient_Update(InnerNetClient* __this, MethodInfo* method)
                     State.LobbyHistory.front().HostName = RemoveHtmlTags(host);
             }
 
+            if (State.VotekickRejoinPending) {
+                State.VotekickRejoinDelay -= Time_get_deltaTime(NULL);
+                if (State.VotekickRejoinDelay <= 0.f) {
+                    State.VotekickRejoinPending = false;
+                    State.JoinLobbyCode = State.VotekickRejoinLobbyCode;
+                    State.JoinLobby = true;
+                }
+            }
+
             // static int joinDelay = 0;
             // if (joinDelay > 0) joinDelay--;
             if (State.JoinLobby/* && joinDelay <= 0*/) {
@@ -1542,6 +1551,11 @@ void dAmongUsClient_OnGameJoined(AmongUsClient* __this, String* gameIdString, Me
             State.assignedRolesPlayer.fill(nullptr);
             State.assignedRoles.fill(RoleType::Random);
 
+            if (!State.PendingRejoinTargetFC.empty())
+                State.PendingRejoinReady = true;
+            else
+                State.VotekickRejoinCount.clear();
+
             /*if (!State.PanicMode) {
                 State.PanicMode = true;
                 State.TempPanicMode = true;
@@ -1861,6 +1875,28 @@ void dVoteBanSystem_AddVote(VoteBanSystem* __this, int32_t srcClient, int32_t cl
             }
             if (State.DisableAllVotekicks) return;
         }
+
+        if (State.AutoRejoinOnKick && !IsHost() && IsInLobby()
+            && sourcePlayer == *Game::pLocalPlayer
+            && !State.LastLobbyJoined.empty()) {
+            int& count = State.VotekickRejoinCount[clientId];
+            count++;
+            if (count <= 2) {
+                auto affectedData = GetPlayerData(affectedPlayer);
+                if (affectedData != nullptr) {
+                    std::string fc = convert_from_string(affectedData->fields.FriendCode);
+                    State.PendingRejoinTargetFC = fc.empty()
+                        ? convert_from_string(NetworkedPlayerInfo_get_PlayerName(affectedData, nullptr))
+                        : fc;
+                }
+                else
+                    State.PendingRejoinTargetFC = convert_from_string(NetworkedPlayerInfo_get_PlayerName(GetPlayerData(affectedPlayer), nullptr));
+                State.VotekickRejoinLobbyCode = State.LastLobbyJoined;
+                State.VotekickRejoinPending = true;
+                State.VotekickRejoinDelay = 0.25f; // a small delay to let the votekick go through.
+            }
+        }
+
         std::string sourceplayerName = convert_from_string(NetworkedPlayerInfo_get_PlayerName(GetPlayerData(sourcePlayer), nullptr));
         std::string affectedplayerName = convert_from_string(NetworkedPlayerInfo_get_PlayerName(GetPlayerData(affectedPlayer), nullptr));
         LOG_DEBUG(sourceplayerName + " attempted to votekick " + affectedplayerName);

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -235,6 +235,7 @@ void Settings::Load() {
         JSON_TRYGET("DisableMeetings", this->DisableMeetings);
         JSON_TRYGET("DisableSabotages", this->DisableSabotages);
         JSON_TRYGET("DisableAllVotekicks", this->DisableAllVotekicks);
+        JSON_TRYGET("AutoRejoinOnKick", this->AutoRejoinOnKick);
         JSON_TRYGET("DisableRoleManager", this->DisableRoleManager);
 
         JSON_TRYGET("ShowRadar", this->ShowRadar);
@@ -836,6 +837,7 @@ void Settings::Save() {
                 { "DisableMeetings", this->DisableMeetings },
                 { "DisableSabotages", this->DisableSabotages },
                 { "DisableAllVotekicks", this->DisableAllVotekicks },
+                { "AutoRejoinOnKick", this->AutoRejoinOnKick },
                 { "DisableRoleManager", this->DisableRoleManager },
 
                 { "ShowRadar", this->ShowRadar },

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -436,6 +436,7 @@ void Settings::Load() {
         JSON_TRYGET("Enable_SMAC", this->Enable_SMAC);
         JSON_TRYGET("SMAC_Punishment", this->SMAC_Punishment);
         JSON_TRYGET("SMAC_HostPunishment", this->SMAC_HostPunishment);
+        JSON_TRYGET("SMAC_ReasonPunishmentOverride", this->SMAC_ReasonPunishmentOverride);
         JSON_TRYGET("SMAC_AddToBlacklist", this->SMAC_AddToBlacklist);
         JSON_TRYGET("SMAC_PunishBlacklist", this->SMAC_PunishBlacklist);
         JSON_TRYGET("SMAC_IgnoreWhitelist", this->SMAC_IgnoreWhitelist);
@@ -1103,6 +1104,7 @@ void Settings::Save() {
                 { "Enable_SMAC", this->Enable_SMAC },
                 { "SMAC_Punishment", this->SMAC_Punishment },
                 { "SMAC_HostPunishment", this->SMAC_HostPunishment },
+                { "SMAC_ReasonPunishmentOverride", this->SMAC_ReasonPunishmentOverride },
                 { "SMAC_AddToBlacklist", this->SMAC_AddToBlacklist },
                 { "SMAC_PunishBlacklist", this->SMAC_PunishBlacklist },
                 { "SMAC_IgnoreWhitelist", this->SMAC_IgnoreWhitelist },

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -465,7 +465,24 @@ void Settings::Load() {
         JSON_TRYGET("SMAC_CheckBadWords", this->SMAC_CheckBadWords);
         JSON_TRYGET("SMAC_BadWords", this->SMAC_BadWords);
         JSON_TRYGET("SMAC_CheckFriendcode", this->SMAC_CheckFriendcode);
-        JSON_TRYGET("ChatPresets", this->ChatPresets);
+        if (j.contains("ChatPresets") && j["ChatPresets"].is_array()) {
+            this->ChatPresets.clear();
+            for (auto& p : j["ChatPresets"]) {
+                Settings::ChatPreset cp;
+                if (p.is_string()) {
+                    cp.Name = "Preset";
+                    cp.Messages = { p.get<std::string>() };
+                }
+                else {
+                    if (p.contains("Name")) cp.Name = p["Name"].get<std::string>();
+                    if (p.contains("Messages") && p["Messages"].is_array()) {
+                        cp.Messages.clear();
+                        for (auto& m : p["Messages"]) cp.Messages.push_back(m.get<std::string>());
+                    }
+                }
+                this->ChatPresets.push_back(cp);
+            }
+        }
 
         JSON_TRYGET("Mod_EnableModeration", this->Mod_EnableModeration);
         JSON_TRYGET("Mod_SickoSocials", this->Mod_SickoSocials);
@@ -473,6 +490,13 @@ void Settings::Load() {
         JSON_TRYGET("Mod_RoleMembers", this->Mod_RoleMembers);
         JSON_TRYGET("Mod_RolePermissions", this->Mod_RolePermissions);
         JSON_TRYGET("Mod_RoleRank", this->Mod_RoleRank);
+
+        if (this->Mod_RoleNames.empty() || this->Mod_RoleNames[0] != "Everyone") {
+            this->Mod_RoleNames.insert(this->Mod_RoleNames.begin(), "Everyone");
+            this->Mod_RoleMembers.insert(this->Mod_RoleMembers.begin(), {});
+            this->Mod_RolePermissions.insert(this->Mod_RolePermissions.begin(), {});
+            this->Mod_RoleRank.insert(this->Mod_RoleRank.begin(), 0);
+        }
         JSON_TRYGET("SMAC_CheckStartWords", this->SMAC_CheckStartWords);
         JSON_TRYGET("SMAC_StartWordsThreshold", this->SMAC_StartWordsThreshold);
         JSON_TRYGET("SMAC_StartWords", this->SMAC_StartWords);
@@ -1108,7 +1132,13 @@ void Settings::Save() {
                 { "SMAC_CheckBadWords", this->SMAC_CheckBadWords },
                 { "SMAC_BadWords", this->SMAC_BadWords },
                 { "SMAC_CheckFriendcode", this->SMAC_CheckFriendcode },
-                { "ChatPresets", this->ChatPresets },
+                { "ChatPresets", [&]() {
+                    nlohmann::json arr = nlohmann::json::array();
+                    for (auto& p : this->ChatPresets) {
+                        arr.push_back({ { "Name", p.Name }, { "Messages", p.Messages } });
+                    }
+                    return arr;
+                    }() },
 
                 { "Mod_EnableModeration", this->Mod_EnableModeration },
                 { "Mod_SickoSocials", this->Mod_SickoSocials },

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -732,6 +732,7 @@ public:
     bool Enable_SMAC = false;
     int SMAC_Punishment = 0;
     int SMAC_HostPunishment = 0;
+    std::unordered_map<std::string, int> SMAC_ReasonPunishmentOverride;
     bool SMAC_AddToBlacklist = false;
     bool SMAC_IgnoreWhitelist = false;
     bool SMAC_PunishBlacklist = false;
@@ -759,12 +760,11 @@ public:
     int SMAC_LowLevel = 0;
     std::vector<uint8_t> SMAC_AttemptBanLobby = {};
     bool SMAC_CheckBadWords = true;
-    std::vector<std::string> SMAC_BadWords = {};
+    std::vector<std::pair<std::string, bool>> SMAC_BadWords = {}; 
     bool SMAC_CheckFriendcode = true;
     bool SMAC_CheckStartWords = false;
-    bool SMAC_StartWordsStrict = true;
     int SMAC_StartWordsThreshold = 1;
-    std::vector<std::string> SMAC_StartWords = {};
+    std::vector<std::pair<std::string, bool>> SMAC_StartWords = {}; 
     std::map<uint8_t, int> SMAC_StartWordsCount;
 
     struct ChatPreset {

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -139,6 +139,13 @@ public:
     int ChatSpamMode = 0;
     int CrashChatSpamMode = 1;
     bool AutoJoinLobby = false;
+    bool AutoRejoinOnKick = false;
+    std::string PendingRejoinTargetFC = "";
+    bool PendingRejoinReady = false;
+    std::unordered_map<int32_t, int> VotekickRejoinCount;
+    bool VotekickRejoinPending = false;
+    float VotekickRejoinDelay = 0.f;
+    std::string VotekickRejoinLobbyCode = "";
     std::string AutoJoinLobbyCode = "";
     bool JoinLobby = false;
     std::string JoinLobbyCode = "";

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -766,7 +766,12 @@ public:
     std::vector<std::string> SMAC_StartWords = {};
     std::map<uint8_t, int> SMAC_StartWordsCount;
 
-    std::vector<std::string> ChatPresets = {};
+    struct ChatPreset {
+        std::string Name = "Preset";
+        std::vector<std::string> Messages = { "" }; 
+    };
+    std::vector<ChatPreset> ChatPresets = {};
+    int SelectedChatPreset = 0;
 
     std::vector<std::string> WhitelistFriendCodes = {};
     std::vector<std::string> BlacklistFriendCodes = {};

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -1919,6 +1919,39 @@ void UpdatePoints(NetworkedPlayerInfo* playerData, float points) {
     State.tournamentPoints[friendCode] += points;
 }
 
+static const std::vector<std::pair<std::string, std::vector<std::string>>> SMAC_REASON_CATEGORIES = {
+    { "Known Cheat Usage", { "AmongUsMenu User", "ChocooMenu User", "KillNetwork User", "SlopMenuCrew User" } },
+    { "SickoMenu Usage", { "SickoMenu User" } },
+    { "Abnormal Names", { "Abnormal Name" } },
+    { "Abnormal Set Color", { "Abnormal Change Color" } },
+    { "Abnormal Set Cosmetics", { "Abnormal Change Cosmetics" } },
+    { "Abnormal Chat Note", { "Abnormal Chat Note" } },
+    { "Abnormal Scanner", { "Abnormal MedBay Scan" } },
+    { "Abnormal Animation", { "Abnormal Animation" } },
+    { "Setting Tasks", { "Abnormal Set Tasks" } },
+    { "Abnormal Murders", { "Abnormal Murder Player" } },
+    { "Abnormal Shapeshift", { "Abnormal Shapeshift" } },
+    { "Abnormal Vanish", { "Abnormal Vanish/Appear" } },
+    { "Abnormal Meetings/Body Reports", { "Abnormal Meeting", "Abnormal Report Body" } },
+    { "Abnormal Venting", { "Abnormal Venting" } },
+    { "Abnormal Chat", { "Abnormal Chat" } },
+    { "Abnormal Task Completion", { "Abnormal Task Completion" } },
+    { "Abnormal Sabotages", { "Bad Sabotage" } },
+    { "Abnormal Player Levels", { "Abnormal Level" } },
+    { "Abnormal Friendcode", { "Abnormal Friendcode" } },
+    { "Blocked Words", { "Bad Word: " } },
+    { "Blocked Start Words", { "Start Word: " } },
+};
+
+static std::string SMAC_GetReasonCategory(const std::string& reason) {
+    for (auto& [category, prefixes] : SMAC_REASON_CATEGORIES) {
+        for (auto& prefix : prefixes) {
+            if (reason.rfind(prefix, 0) == 0) return category;
+        }
+    }
+    return "";
+}
+
 void SMAC_OnCheatDetected(PlayerControl* pCtrl, std::string reason) {
     if (!State.Enable_SMAC) return;
     if (reason == "Overloading" && !(IsHost() && State.SMAC_HostPunishment >= 2)) return; // Don't spam logs for overloading, that causes overload as well
@@ -1946,8 +1979,19 @@ void SMAC_OnCheatDetected(PlayerControl* pCtrl, std::string reason) {
         State.Save();
     }
 
+    std::string smacCategory = SMAC_GetReasonCategory(reason);
+    int punishmentLevel = IsHost() ? State.SMAC_HostPunishment : State.SMAC_Punishment;
+    if (!smacCategory.empty()) {
+        auto overrideIt = State.SMAC_ReasonPunishmentOverride.find(smacCategory);
+        if (overrideIt != State.SMAC_ReasonPunishmentOverride.end())
+            punishmentLevel = overrideIt->second;
+    }
+
+    int maxPunishmentLevel = IsHost() ? 3 : 1;
+    punishmentLevel = std::clamp(punishmentLevel, 0, maxPunishmentLevel);
+
     if (IsHost()) {
-        switch (State.SMAC_HostPunishment) {
+        switch (punishmentLevel) {
         case 0:
             LOG_INFO((name + " has been detected by SickoMenu Anticheat! Reason: " + reason).c_str());
             break;
@@ -1985,7 +2029,7 @@ void SMAC_OnCheatDetected(PlayerControl* pCtrl, std::string reason) {
         }
     }
     else {
-        switch (State.SMAC_Punishment) {
+        switch (punishmentLevel) {
         case 0:
             LOG_INFO((name + " has been detected by SickoMenu Anticheat! Reason: " + reason).c_str());
             break;

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -1311,8 +1311,12 @@ bool FriendCodeHasPermission(const std::string& friendCode, const std::string& c
     if (friendCode.empty()) return false;
     for (size_t i = 0; i < State.Mod_RoleNames.size(); i++) {
         if (i >= State.Mod_RoleMembers.size() || i >= State.Mod_RolePermissions.size()) continue;
-        auto& members = State.Mod_RoleMembers[i];
-        if (std::find(members.begin(), members.end(), friendCode) == members.end()) continue;
+        bool isMember = i == 0; 
+        if (!isMember) {
+            auto& members = State.Mod_RoleMembers[i];
+            isMember = std::find(members.begin(), members.end(), friendCode) != members.end();
+        }
+        if (!isMember) continue;
         auto it = State.Mod_RolePermissions[i].find(commandKey);
         if (it != State.Mod_RolePermissions[i].end() && it->second) return true;
     }
@@ -1361,7 +1365,7 @@ PlayerControl* ResolveTargetByColor(int colorId) {
 std::vector<int> GetFriendCodeRoleIndices(const std::string& friendCode) {
     std::vector<int> result;
     if (friendCode.empty()) return result;
-    for (size_t i = 0; i < State.Mod_RoleMembers.size(); i++) {
+    for (size_t i = 1; i < State.Mod_RoleMembers.size(); i++) { 
         auto& members = State.Mod_RoleMembers[i];
         if (std::find(members.begin(), members.end(), friendCode) != members.end()) result.push_back((int)i);
     }
@@ -1378,12 +1382,16 @@ void SetFriendCodeInRole(const std::string& friendCode, int roleIndex, bool memb
 }
 
 int GetFriendCodeMaxRank(const std::string& friendCode) {
-    int maxRank = -1; //-1 = holds no roles at all, always outranked by any real role
+    int maxRank = 0; 
     if (friendCode.empty()) return maxRank;
     for (size_t i = 0; i < State.Mod_RoleNames.size(); i++) {
         if (i >= State.Mod_RoleMembers.size() || i >= State.Mod_RoleRank.size()) continue;
-        auto& members = State.Mod_RoleMembers[i];
-        if (std::find(members.begin(), members.end(), friendCode) == members.end()) continue;
+        bool isMember = i == 0; 
+        if (!isMember) {
+            auto& members = State.Mod_RoleMembers[i];
+            isMember = std::find(members.begin(), members.end(), friendCode) != members.end();
+        }
+        if (!isMember) continue;
         if (State.Mod_RoleRank[i] > maxRank) maxRank = State.Mod_RoleRank[i];
     }
     return maxRank;

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -1941,6 +1941,7 @@ static const std::vector<std::pair<std::string, std::vector<std::string>>> SMAC_
     { "Abnormal Friendcode", { "Abnormal Friendcode" } },
     { "Blocked Words", { "Bad Word: " } },
     { "Blocked Start Words", { "Start Word: " } },
+    { "Blacklisted Players", { "<#f00>Blacklisted!</color>" } },
 };
 
 static std::string SMAC_GetReasonCategory(const std::string& reason) {
@@ -1975,8 +1976,7 @@ void SMAC_OnCheatDetected(PlayerControl* pCtrl, std::string reason) {
     if (fc != "" && State.SMAC_IgnoreWhitelist && it != State.WhitelistFriendCodes.end()) return;
     if (fc != "" && State.SMAC_AddToBlacklist) {
         if (it != State.WhitelistFriendCodes.end()) State.WhitelistFriendCodes.erase(it);
-        State.BlacklistFriendCodes.push_back(fc);
-        State.Save();
+        AddToBlacklist(fc); 
     }
 
     std::string smacCategory = SMAC_GetReasonCategory(reason);


### PR DESCRIPTION
### "Everyone" Moderation Role

- A  indestructible role automatically applied to any player without needing to be assigned, migrated in for existing configs via a one-time backfill on load.
- Can't be deleted or ranked (rank editor and Delete Role are hidden for it), and has no member list since it's implicit, permissions are applied as usual.
- Role rank floor is now enforced at 0 across the board so can't set a real role below the everyone role.
### /preset command
- Replaces the old single hardcoded /rules command with permission-gated, user-defined chat presets.
- **Usable two ways**: /preset (name), or a direct shorthand /(name) matching any saved preset.
- Multi-message presets (built via Combined mentioned below) send in order with a 2s delay between messages, reusing the existing staged-message queue.
### Chat Presets (Game tab)
- Presets are now named, not just raw text, shown by name in the selector instead of dumping message content into the list.
- New "Combine Presets": pick 2+ single-message presets, combine into one named multi-message preset for /preset/shorthand to send as a sequence.
Helpful for Rules which are necessary to be sent in separate messages due to character limits.

### Anticheat Punishment & Improvements

- Detection mode (Default/Strict) for 'Blocked Words/Blocked Start Words' is now set **per word** instead of one global toggle for the entire list
- Prevented adding duplicate words and empty entries
- Added the ability to decide individual actions for each SMAC detections
<img width="749" height="563" alt="image" src="https://github.com/user-attachments/assets/13053489-479e-42ea-b637-0576bd8074c1" />

### Auto-Rejoin on Votekick
- When toggled on automatically rejoins the lobby after a votekick and reselects the votekicked player on the players tab upon rejoin and stops the rejoin for the 3rd & last votekick.

### Bugfix
- Fixed 'Add cheaters to blacklist' adding the same user's friendcode multiple times for multiple detections.
- Fixed Blocked Start Words not working.