### PR TITLE
Update state.cpp

### DIFF
--- a/user/state.cpp
+++ b/user/state.cpp
@@ -37,7 +37,7 @@ void Settings::Load() {
     }
 
     auto settingsPath = path.parent_path() / std::format("sicko-config/{}.json", this->selectedConfig);
-
+    this->dpiChanged = true;
     if (!std::filesystem::exists(settingsPath))
         return;
 
@@ -60,7 +60,6 @@ void Settings::Load() {
         JSON_TRYGET("ShowDebug", this->showDebugTab);
 #endif
         JSON_TRYGET("dpiScale", this->dpiScale);
-        this->dpiChanged = true;
         JSON_TRYGET("RgbTheme", this->RgbMenuTheme);
         JSON_TRYGET("GradientTheme", this->GradientMenuTheme);
         JSON_TRYGET("MatchBackgroundWithTheme", this->MatchBackgroundWithTheme);


### PR DESCRIPTION
on a fresh install with no sicko-config text gets clipped/cut off in multiple places across the menu. turning on any feature (which creates the config file) and relaunching fixes it completely every time but without config it gonna cut off the features look at the screenshots 

some cut off features in the menu:
- self > utils > Always Move (always mo)
- self > randomizer > meeting (meeti)
- self > text editor > rotation angle ( rotation angl)
- about > welcome > github offical discord! (Gith)
- game > antiCheat > Ignore whitelist (whiteli)
- game > antiCheat > Abnormal chat note (abnormal chat n)
- reply > Show Only Last Second (Show Only Last Secon)
<img width="127" height="33" alt="image" src="https://github.com/user-attachments/assets/91ec401f-5eac-4341-8304-5e2530d19593" />
