### PR TITLE
Fix mismatched rich-text tags, null derefs, and small correctness bugs

### DIFF
--- a/hooks/Chat.cpp
+++ b/hooks/Chat.cpp
@@ -414,7 +414,7 @@ static bool HandleChatCommand(PlayerControl* actor, const std::string& message) 
 					}
 					else {
 						auto targetPd = GetPlayerData(target);
-						std::string targetName = convert_from_string(NetworkedPlayerInfo_get_PlayerName(targetPd, nullptr));
+						std::string targetName = (targetPd != NULL) ? convert_from_string(NetworkedPlayerInfo_get_PlayerName(targetPd, nullptr)) : "";
 						std::string targetFc = (targetPd != NULL && targetPd->fields.FriendCode != NULL) ? convert_from_string(targetPd->fields.FriendCode) : "";
 						if (targetFc.empty()) {
 							localWarn("<#ff0000><size=-0.24><font=\"Barlow-Regular Masked\"><b>That player has no friend code available.</b></font></color>");
@@ -455,7 +455,7 @@ static bool HandleChatCommand(PlayerControl* actor, const std::string& message) 
 					}
 					else {
 						auto targetPd = GetPlayerData(target);
-						std::string targetName = convert_from_string(NetworkedPlayerInfo_get_PlayerName(targetPd, nullptr));
+						std::string targetName = (targetPd != NULL) ? convert_from_string(NetworkedPlayerInfo_get_PlayerName(targetPd, nullptr)) : "";
 						std::string fc = (targetPd != NULL && targetPd->fields.FriendCode != NULL) ? convert_from_string(targetPd->fields.FriendCode) : "";
 						auto it = State.WarnReasons.find(fc);
 						if (fc.empty() || it == State.WarnReasons.end() || reasonIndex >= (int)it->second.size()) {

--- a/hooks/EOSManager.cpp
+++ b/hooks/EOSManager.cpp
@@ -208,7 +208,7 @@ void dEditAccountUsername_SaveUsername(EditAccountUsername* __this, MethodInfo* 
 	}
 	else {
 		auto textStr = TMP_Text_get_text((TMP_Text*)__this->fields.UsernameText, NULL);
-		if (textStr != convert_to_string("")) {
+		if (!convert_from_string(textStr).empty()) {
 			std::string newFriendCode = "";
 			for (auto i : convert_from_string(textStr)) {
 				newFriendCode += tolower(i);

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -268,7 +268,8 @@ void dInnerNetClient_Update(InnerNetClient* __this, MethodInfo* method)
             }
 
             if (State.SnipeColor && (IsInGame() || IsInLobby())) {
-                if ((IsColorAvailable(State.SelectedColorId) || !State.SafeMode) && GetPlayerOutfit(GetPlayerData(*Game::pLocalPlayer))->fields.ColorId != State.SelectedColorId) {
+                auto localOutfit = GetPlayerOutfit(GetPlayerData(*Game::pLocalPlayer));
+                if (localOutfit != NULL && (IsColorAvailable(State.SelectedColorId) || !State.SafeMode) && localOutfit->fields.ColorId != State.SelectedColorId) {
                     std::queue<RPCInterface*>* queue = nullptr;
                     if (IsInGame())
                         queue = &State.rpcQueue;

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -442,10 +442,9 @@ PlayerControl* GetPlayerControlById(Game::PlayerId id) {
 
 bool IsColorAvailable(int colorId) {
     for (auto player : GetAllPlayerData()) {
-        if (GetPlayerOutfit(player)->fields.ColorId == colorId) { //aw hell nah, i made a classic mistake: forgetting another =
-            return false;
-            break;
-        }
+        auto outfit = GetPlayerOutfit(player);
+        if (outfit == NULL) continue;
+        if (outfit->fields.ColorId == colorId) return false;
     }
     return true;
 }
@@ -459,7 +458,7 @@ std::string GenerateRandomString(bool completelyRandom) {
         std::string outputString = "";
 
         for (int i = 0; i < outputLength; ++i) {
-            randomIndex = rand() % (allowedChars.length() - 1);
+            randomIndex = rand() % allowedChars.length();
             outputString += allowedChars[randomIndex];
         }
         return outputString;
@@ -1067,8 +1066,8 @@ std::string GetGradientUsername(std::string str, ImVec4 color1, ImVec4 color2, i
     if (State.StrikethroughName) opener += "<s>";
 
     std::string closer = "";
-    if (State.UnderlineName) closer += "</s>";
-    if (State.StrikethroughName) closer += "</u>";
+    if (State.StrikethroughName) closer += "</s>";
+    if (State.UnderlineName) closer += "</u>";
 
     if (hex1 == hex2) //if user doesn't want gradients, don't cause extra lag
         return std::format("<#{:02x}{:02x}{:02x}{:02x}>{}{}{}</color>", hex1[0], hex1[1], hex1[2], hex2[3], opener, str, closer);


### PR DESCRIPTION
Found these while reading through the source. All small and self-contained — no behaviour changes beyond making the existing intent work.

### 1. `GetGradientUsername` closes `<u>` with `</s>` and `<s>` with `</u>`

`user/utility.cpp` — opener and closer are built in the same order, so the tags come out swapped:

```cpp
if (State.UnderlineName)     opener += "<u>";
if (State.StrikethroughName) opener += "<s>";

std::string closer = "";
if (State.UnderlineName)     closer += "</s>";  // closes <s>
if (State.StrikethroughName) closer += "</u>";  // closes <u>
```

With only Underline enabled you get `<u>name</s>`; with only Strikethrough, `<s>name</u>`. Both-on works by accident, because the swap happens to nest correctly. The same logic is written correctly further down the same file, which is what convinced me this is a typo rather than intent.

### 2. `IsColorAvailable` dereferences `GetPlayerOutfit()` without a null check

`GetPlayerOutfit` returns `dic[PlayerOutfitType__Enum::Default]`, and `il2cpp::Dictionary::operator[]` returns `nullptr` for a missing key. `GetRandomColorId` in the same file already guards this with `if (outfit == NULL) continue;` — `IsColorAvailable` doesn't, and it runs every frame from the Snipe Color path, including while players are still joining. Same unchecked deref on the local player's outfit in the Snipe Color block in `hooks/InnerNetClient.cpp`, which I hoisted into a local so it's only looked up once.

Also dropped a `break` that was unreachable after `return false`.

### 3. `/warn` and `/unwarn` use `targetPd` one line before checking it for null

```cpp
auto targetPd = GetPlayerData(target);
std::string targetName = convert_from_string(NetworkedPlayerInfo_get_PlayerName(targetPd, nullptr));
std::string targetFc = (targetPd != NULL && ...) ? ... : "";
```

The check on the very next line shows the null case was expected; the il2cpp call above it just missed it. Matched the existing ternary style rather than restructuring the block.

### 4. `dEditAccountUsername_SaveUsername` compares string pointers, not contents

```cpp
if (textStr != convert_to_string("")) {
```

`convert_to_string` returns a freshly allocated `app::String*` from `il2cpp_string_new_len` on every call, so this comparison is always true — the `else` branch that generates a random friend code when the field is empty was unreachable. Now compares the converted `std::string`, which also handles a null `textStr` correctly.

### 5. `GenerateRandomString(true)` can never emit the last allowed character

`rand() % (allowedChars.length() - 1)` excludes `'z'`.

---

Built clean on CI (Release and Debug, x86 and x64). Not tested in-game, since these are null guards and a tag fix rather than behavioural changes. Happy to split this into separate PRs if you'd prefer them reviewed independently.