### PR TITLE
Fix "Kill Other Imposters" not working via proximity

### DIFF
--- a/hooks/PlayerControl.cpp
+++ b/hooks/PlayerControl.cpp
@@ -1432,7 +1432,7 @@ PlayerControl* dImpostorRole_FindClosestTarget(ImpostorRole* __this, MethodInfo*
     if (State.ShowHookLogs) Log.HookDebug("Hook dImpostorRole_FindClosestTarget executed", false);
     if (IsInLobby()) return nullptr;
     auto result = ImpostorRole_FindClosestTarget(__this, method);
-    if (!State.PanicMode && result == nullptr && (State.InfiniteKillRange || (State.KillInVanish && IsHost() || !State.SafeMode))) {
+    if (!State.PanicMode && (State.KillImpostors || result == nullptr) && (State.KillImpostors || State.InfiniteKillRange || (State.KillInVanish && IsHost() || !State.SafeMode))) {
         PlayerControl* new_result = nullptr;
         float defaultKillDist = 2.5f;
         auto killDistSetting = GameOptions().GetInt(Int32OptionNames__Enum::KillDistance);


### PR DESCRIPTION
The kill button showed blurred/unusable when approaching another impostor, even with "Kill Other Imposters" enabled killing only worked through the manual player tab selection (which queues the RPC directly, bypassing this code path). the issue: in hooks/PlayerControl.cpp, dImpostorRole_FindClosestTarget's fallback target-scan guard condition never checked State.KillImpostors: if (!State.PanicMode && result == nullptr && (State.InfiniteKillRange  (State.KillInVanish && IsHost()  !State.SafeMode))) { So unless InfiniteKillRange or KillInVanish+host or SafeMode off was also set, the scan never ran and no target was ever found for the kill button, regardless of KillImpostors. Fix: added State.KillImpostors || to the guard so the scan runs whenever the option is enabled.