### PR TITLE
New features

### DIFF
--- a/appdata/il2cpp-functions.h
+++ b/appdata/il2cpp-functions.h
@@ -510,3 +510,5 @@ DO_APP_FUNC(void, VentilationSystem_UpdateSystem, (VentilationSystem* __this, Pl
 DO_APP_FUNC(bool, Player_GetButton, (Player* __this, int32_t actionId, MethodInfo* method), "Rewired_Core, System.Boolean Rewired.Player::GetButton(System.Int32)");
 DO_APP_FUNC(void, KillButton_DoClick, (KillButton* __this, MethodInfo* method), "Assembly-CSharp, System.Void KillButton::DoClick()");
 DO_APP_FUNC(void, VentButton_DoClick, (VentButton* __this, MethodInfo* method), "Assembly-CSharp, System.Void VentButton::DoClick()");
+
+DO_APP_FUNC(void, InnerNetClient_SetEndpoint, (InnerNetClient* __this, String* addr, uint16_t port, bool dtls, MethodInfo* method), "Assembly-CSharp, System.Void InnerNet.InnerNetClient::SetEndpoint(System.String, System.UInt16, System.Boolean)");

--- a/appdata/il2cpp-functions.h
+++ b/appdata/il2cpp-functions.h
@@ -126,6 +126,7 @@ DO_APP_FUNC(void*, PlayerControl_CoSetRole, (PlayerControl* __this, RoleTypes__E
 DO_APP_FUNC(void, PlayerControl_RpcSetScanner, (PlayerControl* __this, bool value, MethodInfo* method), "Assembly-CSharp, System.Void PlayerControl::RpcSetScanner(System.Boolean)");
 DO_APP_FUNC(void, PlayerControl_SetScanner, (PlayerControl* __this, bool on, uint8_t cnt), "Assembly-CSharp, System.Void PlayerControl::SetScanner(System.Boolean, System.Byte)");
 DO_APP_FUNC(void, PlayerControl_CmdCheckColor, (PlayerControl* __this, uint8_t bodyColor, MethodInfo* method), "Assembly-CSharp, System.Void PlayerControl::CmdCheckColor(System.Byte)");
+DO_APP_FUNC(void, PlayerControl_CheckColor, (PlayerControl* __this, uint8_t bodyColor, MethodInfo* method), "Assembly-CSharp, System.Void PlayerControl::CheckColor(System.Byte)");
 DO_APP_FUNC(void, PlayerControl_RpcSetColor, (PlayerControl* __this, uint8_t bodyColor, MethodInfo* method), "Assembly-CSharp, System.Void PlayerControl::RpcSetColor(System.Byte)");
 DO_APP_FUNC(void, PlayerControl_CmdCheckName, (PlayerControl* __this, String* name, MethodInfo* method), "Assembly-CSharp, System.Void PlayerControl::CmdCheckName(System.String)");
 DO_APP_FUNC(void, PlayerControl_RpcSetLevel, (PlayerControl* __this, uint32_t level, MethodInfo* method), "Assembly-CSharp, System.Void PlayerControl::RpcSetLevel(System.UInt32)");

--- a/gui/tabs/host_tab.cpp
+++ b/gui/tabs/host_tab.cpp
@@ -529,6 +529,10 @@ namespace HostTab {
                     State.Save();
                 }
 
+				if (ToggleButton("Allow Join with Prefered Color", &State.AllowPreferedColor)) {
+                    State.Save();
+                }
+
                 if (!State.SafeMode) {
                     if (ToggleButton("Force Name for Everyone", &State.ForceNameForEveryone)) {
                         State.Save();

--- a/gui/tabs/host_tab.cpp
+++ b/gui/tabs/host_tab.cpp
@@ -529,7 +529,7 @@ namespace HostTab {
                     State.Save();
                 }
 
-				if (ToggleButton("Allow Join with Prefered Color", &State.AllowPreferedColor)) {
+				if (ToggleButton("Allow Join with Preferred Color", &State.AllowPreferredColor)) {
                     State.Save();
                 }
 

--- a/gui/tabs/players_tab.cpp
+++ b/gui/tabs/players_tab.cpp
@@ -42,6 +42,7 @@ namespace PlayersTab {
         std::string nameClean;
         std::string friendCode;
         std::string puid;
+        std::string platform;
         std::string platformName;
         uint64_t psnId = 0;
         uint64_t xboxId = 0;
@@ -66,13 +67,16 @@ namespace PlayersTab {
         g_PlayerCache.clear();
     }
 
-    std::string GetPlatformString(PlayerControl* playerCtrl, app::ClientData* client, uint64_t& outPsn, uint64_t& outXbox) {
+    std::string GetPlatformString(PlayerControl* playerCtrl, app::ClientData* client, uint64_t& outPsn, uint64_t& outXbox, std::string& platformName) {
         if (client == NULL || client->fields.PlatformData == NULL || playerCtrl->fields._.OwnerId != client->fields.Id) {
             return "Unknown";
         }
 
         outPsn = client->fields.PlatformData->fields.PsnPlatformId;
         outXbox = client->fields.PlatformData->fields.XboxPlatformId;
+
+        // By default, all players have "TESTNAME", except Switch/PlayStation/XBOX (using account names)
+        platformName = convert_from_string(client->fields.PlatformData->fields.PlatformName);
 
         switch (client->fields.PlatformData->fields.Platform) {
         case Platforms__Enum::StandaloneEpicPC:
@@ -191,7 +195,7 @@ namespace PlayersTab {
                         cache.puid = convert_from_string(playerData->fields.Puid);
 
                         app::ClientData* client = (app::ClientData*)app::InnerNetClient_GetClientFromCharacter((app::InnerNetClient*)(*Game::pAmongUsClient), playerCtrl, NULL);
-                        cache.platformName = GetPlatformString(playerCtrl, client, cache.psnId, cache.xboxId);
+                        cache.platform = GetPlatformString(playerCtrl, client, cache.psnId, cache.xboxId, cache.platformName);
 
                         if (!cache.isCached) {
                             cache.selectableId = "##" + ToString(pid);
@@ -461,7 +465,8 @@ namespace PlayersTab {
                         uint32_t playerLevel = selectedPlayer.get_PlayerData()->fields.PlayerLevel + 1;
                         ImGui::Text("Level: %d", playerLevel);
 
-                        ImGui::Text("Platform: %s", cachedDetails.platformName.c_str());
+                        ImGui::Text("Platform: %s", cachedDetails.platform.c_str());
+                        ImGui::Text("Platform Name: %s", cachedDetails.platformName.c_str());
 
                         std::string friendCode = cachedDetails.friendCode;
                         bool isWhitelisted = std::find(State.WhitelistFriendCodes.begin(), State.WhitelistFriendCodes.end(), friendCode) != State.WhitelistFriendCodes.end();

--- a/gui/tabs/self_tab.cpp
+++ b/gui/tabs/self_tab.cpp
@@ -655,6 +655,10 @@ namespace SelfTab {
             if (ToggleButton("Better Message Sounds", &State.BetterMessageSounds)) {
                 State.Save();
             }
+            ImGui::SameLine();
+            if (ToggleButton("Extended Notifications", &State.ExtendedNotifications)) {
+                State.Save();
+            }
 
             if (ToggleButton("Auto Rejoin After Game Ending", &State.AutoRejoin)) {
                 State.Save();

--- a/gui/tabs/settings_tab.cpp
+++ b/gui/tabs/settings_tab.cpp
@@ -394,6 +394,16 @@ namespace SettingsTab {
 				}
 			}
 
+			if (ToggleButton("Spoof Platform Name", &State.SpoofPlName)) {
+				State.Save();
+			}
+			if (State.SpoofPlName)
+			{
+				ImGui::SameLine();
+				ImGui::SetNextItemWidth(150 * State.dpiScale);
+				InputString("Platform Name", &State.FakePlName);
+			}
+
 			static bool dhaWarnState = false;
 
 			if (!dhaWarnState && ToggleButton("Reduce Anticheat While Hosting (+25 Mode)", &State.DisableHostAnticheat)) {
@@ -430,6 +440,70 @@ namespace SettingsTab {
 				if (ColoredButton(ImVec4(1.f, 0.f, 0.f, 1.f), "No")) {
 					dhaWarnState = false;
 				}
+			}
+
+			static bool cssWarnState = false;
+
+			if (!cssWarnState && ToggleButton("Custom Server Settings", &State.UseCustomServer)) {
+				if (State.UseCustomServer) {
+					cssWarnState = true;
+					State.UseCustomServer = false;
+				}
+				else {
+					State.Save();
+				}
+			}
+
+			if (cssWarnState) {
+				BoldText("Warning", ImVec4(1.f, 0.f, 0.f, 1.f));
+				ImGui::Text("\"Custom Server Settings\" feature forces all newly created lobbies");
+				ImGui::Text("to use specified Innersloth IP address and port of the server.");
+				ImGui::Text(" ");
+				ImGui::Text("Last 4 letters of the lobby code are automatically generated");
+				ImGui::Text("based on the IP address and port you set.");
+				ImGui::Text(" ");
+				ImGui::Text("While active, you cannot join other servers or use the");
+				ImGui::Text("\"Reduce Anticheat While Hosting (+25 Mode)\" feature.");
+				ImGui::Text(" ");
+				ImGui::Text("To find the required IP and port, enable \"Show Lobby Info\"");
+				ImGui::Text("and check lobbies in Matchmaking.");
+				ImGui::Text(" ");
+				ImGui::Text("Are you sure you want to enable this?");
+
+				if (ColoredButton(ImVec4(0.f, 1.f, 0.f, 1.f), "Yes")) {
+					cssWarnState = false;
+					State.UseCustomServer = true;
+					State.Save();
+				}
+				ImGui::SameLine();
+				if (ColoredButton(ImVec4(1.f, 0.f, 0.f, 1.f), "No")) {
+					cssWarnState = false;
+				}
+			}
+
+			if (State.UseCustomServer) {
+				static char ipBuffer[128] = "";
+
+				if (ipBuffer[0] == '\0' && !State.CustomServerIp.empty()) {
+					strncpy_s(ipBuffer, State.CustomServerIp.c_str(), sizeof(ipBuffer));
+				}
+
+				if (ImGui::InputText("Server IP", ipBuffer, sizeof(ipBuffer))) {
+					State.CustomServerIp = ipBuffer;
+				}
+
+				int port = static_cast<int>(State.CustomServerPort);
+				if (ImGui::InputInt("Server Port", &port, 1, 100)) {
+					if (port < 1) port = 1;
+					if (port > 65535) port = 65535;
+					State.CustomServerPort = static_cast<uint16_t>(port);
+				}
+			}
+
+			ImGui::Spacing();
+
+			if (ToggleButton("Force DTLS", &State.ForceDTLS)) {
+				State.Save();
 			}
 			/*if (State.DisableHostAnticheat) {
 				BoldText("Warning (+25 Mode)", ImVec4(1.f, 0.f, 0.f, 1.f));

--- a/hooks/EOSManager.cpp
+++ b/hooks/EOSManager.cpp
@@ -167,30 +167,12 @@ String* dEOSManager_get_ProductUserId(EOSManager* __this, MethodInfo* method) {
 	return puid;
 }
 
-
-//Encrypted PUID Spoofing code [Undetectable]
-
-/*static void f1(const char* c1) {
-	if (a2.b2) {
-		int c2 = (c1[0] != 0) ? 1 : 0;
-		LOG_DEBUG("Vtpnq1");
-	}
-}
-
-static String* f2() {
-	if (a2.c3 && !a2.d4.empty()) {
-		int c3 = a2.d4.size();
-		String* c4 = f3(a2.d4);
-		return c4;
-	}
-	return nullptr;
-}*/
-
 void dPlatformSpecificData_Serialize(PlatformSpecificData* __this, MessageWriter* writer, MethodInfo* method) {
 	if (State.ShowHookLogs) Log.HookDebug("Hook dPlatformSpecificData_Serialize executed", false);
 	if (State.SpoofPlatform) __this->fields.Platform = Platforms__Enum(State.FakePlatform + 1);
 	if (State.FakePlatform == 8) __this->fields.XboxPlatformId = State.FakeXboxId;
 	if (State.FakePlatform == 9) __this->fields.PsnPlatformId = State.FakePsnId;
+	if (State.SpoofPlName) __this->fields.PlatformName = convert_to_string(State.FakePlName);
 	PlatformSpecificData_Serialize(__this, writer, method);
 }
 

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -1575,18 +1575,10 @@ void dAmongUsClient_OnPlayerLeft(AmongUsClient* __this, ClientData* data, Discon
         if (data->fields.Character) { // Don't use Object_1_IsNotNull().
             auto playerInfo = GetPlayerData(data->fields.Character);
 
-            if (reason == DisconnectReasons__Enum::Banned)
-                Log.Debug(convert_from_string(data->fields.PlayerName) + " has been banned by host (" + GetHostUsername() + ").");
-            else if (reason == DisconnectReasons__Enum::Kicked)
-                Log.Debug(convert_from_string(data->fields.PlayerName) + " has been kicked by host (" + GetHostUsername() + ").");
-            else if (reason == DisconnectReasons__Enum::Hacking)
-                Log.Debug(convert_from_string(data->fields.PlayerName) + " has been banned for hacking.");
-            else if (reason == DisconnectReasons__Enum::Error)
-                Log.Debug(convert_from_string(data->fields.PlayerName) + " has been disconnected due to error.");
-            else if (reason == DisconnectReasons__Enum::Sanctions)
-                Log.Debug(convert_from_string(data->fields.PlayerName) + " has been sanction-banned.");
-            else
-                Log.Debug(convert_from_string(data->fields.PlayerName) + " has left the game.");
+            const std::string playerName = convert_from_string(data->fields.PlayerName);
+            const std::string stringReason = GetDisconnectReasonString(reason);
+
+            Log.Debug(playerName + " left by reason: " + stringReason);
 
             uint8_t playerId = data->fields.Character->fields.PlayerId;
 
@@ -1619,6 +1611,22 @@ void dAmongUsClient_OnPlayerLeft(AmongUsClient* __this, ClientData* data, Discon
                     State.liveConsoleEvents.emplace_back(std::make_unique<DisconnectEvent>(evtPlayer.value()));
                 }
             }
+
+            if (State.ExtendedNotifications) {
+                const bool smacPunished = State.SMAC_PunishedPlayers.find(playerId) != State.SMAC_PunishedPlayers.end();
+
+                if (smacPunished) {
+                    State.SMAC_PunishedPlayers.erase(playerId);
+                }
+
+                if (!smacPunished) {
+                    if (auto* notifier = (NotificationPopper*)Game::HudManager.GetInstance()->fields.Notifier) {
+                        std::string notifyText = "Left: " + convert_from_string(data->fields.PlayerName) + " by reason: " + stringReason;
+                        NotificationPopper_AddDisconnectMessage(notifier, convert_to_string(notifyText), nullptr);
+                        State.IgnoreOriginalInit_NotificationPopper = true;
+                    }
+                }
+            }
         }
         else {
             //Found this happens on game ending occasionally
@@ -1635,6 +1643,30 @@ void dAmongUsClient_OnPlayerLeft(AmongUsClient* __this, ClientData* data, Discon
 void dAmongUsClient_OnPlayerJoined(AmongUsClient* __this, ClientData* data, MethodInfo* method) {
     if (State.ShowHookLogs) Log.HookDebug("Hook dAmongUsClient_OnPlayerJoined executed", false);
     State.BlinkPlayersTab = true;
+
+    if (!data) return;
+
+    if (State.ExtendedNotifications) {
+        std::string name = data->fields.PlayerName != nullptr ? convert_from_string(data->fields.PlayerName) : "<N/A>";
+        std::string friendCode = data->fields.FriendCode != nullptr ? convert_from_string(data->fields.FriendCode) : "<N/A>";
+
+        if (friendCode.empty()) friendCode = "N/A";
+
+        if (auto* notifier = (NotificationPopper*)Game::HudManager.GetInstance()->fields.Notifier) {
+            AudioClip* soundBackup = notifier->fields.playerDisconnectSound;
+            Color colorBackup = notifier->fields.disconnectColor;
+
+            notifier->fields.disconnectColor = Color(0.0f, 1.0f, 0.0f, 1.0f);
+            notifier->fields.playerDisconnectSound = nullptr;
+
+            std::string notifyText = std::format("Joined: <noparse>{}</noparse> | <noparse>{}</noparse>", name, friendCode);
+            NotificationPopper_AddDisconnectMessage(notifier, convert_to_string(notifyText), nullptr);
+
+            notifier->fields.playerDisconnectSound = soundBackup;
+            notifier->fields.disconnectColor = colorBackup;
+        }
+    }
+
     AmongUsClient_OnPlayerJoined(__this, data, method);
 }
 
@@ -1952,4 +1984,35 @@ void dDisconnectPopup_DoShow(DisconnectPopup* __this, MethodInfo* method) {
 bool dGameManager_DidImpostorsWin(GameManager* __this, GameOverReason__Enum reason, MethodInfo* method) {
     if (State.ShowHookLogs) Log.HookDebug("Hook dGameManager_DidImpostorsWin executed", false);
     return GameManager_DidImpostorsWin(__this, reason, method);
+}
+
+void dInnerNetClient_SetEndpoint(InnerNetClient* __this, String* addr, uint16_t port, bool dtls, MethodInfo* method) {
+    if (State.ShowHookLogs) Log.HookDebug("Hook dInnerNetClient_SetEndpoint executed", false);
+    try {
+        if (State.UseCustomServer && !State.CustomServerIp.empty()) {
+            addr = convert_to_string(State.CustomServerIp);
+            port = State.CustomServerPort;
+        }
+
+        if (State.ForceDTLS) {
+            dtls = true;
+        }
+    }
+    catch (...) {
+        LOG_ERROR("Exception in dInnerNetClient_SetEndpoint");
+    }
+
+    InnerNetClient_SetEndpoint(__this, addr, port, dtls, method);
+}
+
+// Ignores the original NotificationPopper initialization method
+void dNotificationPopper_AddDisconnectMessage(NotificationPopper* __this, String* item, MethodInfo* method) {
+    if (State.ShowHookLogs) Log.HookDebug("Hook dNotificationPopper_AddDisconnectMessage executed", false);
+
+    if (State.IgnoreOriginalInit_NotificationPopper) {
+        State.IgnoreOriginalInit_NotificationPopper = false;
+        return;
+    }
+
+    NotificationPopper_AddDisconnectMessage(__this, item, method);
 }

--- a/hooks/LobbyBehaviour.cpp
+++ b/hooks/LobbyBehaviour.cpp
@@ -146,6 +146,17 @@ void dGameContainer_SetupGameInfo(GameContainer* __this, MethodInfo* method) {
     if (State.PanicMode || !State.ShowLobbyInfo) return GameContainer_SetupGameInfo(__this, method);
     GameContainer_SetupGameInfo(__this, method);
     auto gameListing = __this->fields.gameListing;
+
+    uint32_t ip = gameListing.IP;
+    std::string ipAddress = std::format("{}.{}.{}.{}",
+        (ip & 0xFF),
+        (ip >> 8) & 0xFF,
+        (ip >> 16) & 0xFF,
+        (ip >> 24) & 0xFF
+    );
+    uint16_t port = gameListing.Port;
+    std::string ipPortDisplay = std::format("\n<#0fb>IP: {}:{}</color>", ipAddress, port);
+
     auto platform = gameListing.Platform;
     std::string platformId = "Unknown";
     switch (platform) {
@@ -206,8 +217,8 @@ void dGameContainer_SetupGameInfo(GameContainer* __this, MethodInfo* method) {
     const std::unordered_set<std::string> BannedNamesSet(State.LockedNames.begin(), State.LockedNames.end());
     if (BannedNamesSet.find(trueHostName) != BannedNamesSet.end()) trueHostName = nameCheckerCol + trueHostName + "</color>"; // Yellow color for banned names
     std::string separator = "<#0000>000000000000000</color>"; // The crewmate icon gets aligned properly with this
-    std::string playerCountDisplay = std::format("<size=40%>{}\n{}{}</color>\n{}\n{}{}</color>\n{}{}</color>{}\n{}</size>",
-        separator, hostCol, trueHostName, playerCount, lobbyCodeCol, lobbyCode, platformCol, platformId, lobbyTimeDisplay, separator);
+    std::string playerCountDisplay = std::format("<size=40%>{}\n{}{}</color>\n{}\n{}{}</color>\n{}{}</color>{}{}\n{}</size>",
+        separator, hostCol, trueHostName, playerCount, lobbyCodeCol, lobbyCode, platformCol, platformId, ipPortDisplay, lobbyTimeDisplay, separator);
     TMP_Text_set_text((TMP_Text*)__this->fields.capacity, convert_to_string(playerCountDisplay), NULL);
 }
 

--- a/hooks/PlayerControl.cpp
+++ b/hooks/PlayerControl.cpp
@@ -1866,3 +1866,14 @@ void dPlayerControl_SetKillTimer(PlayerControl* __this, float time, MethodInfo* 
 
     PlayerControl_SetKillTimer(__this, time, method);
 }
+
+void dPlayerControl_CheckColor(PlayerControl* __this, uint8_t bodyColor, MethodInfo* method) {
+    if (State.ShowHookLogs) Log.HookDebug("Hook dPlayerControl_CheckColor executed", false);
+
+    if (!State.AllowPreferedColor) {
+        PlayerControl_CheckColor(__this, bodyColor, method);
+        return;
+    }
+
+    PlayerControl_RpcSetColor(__this, bodyColor, NULL);
+}

--- a/hooks/PlayerControl.cpp
+++ b/hooks/PlayerControl.cpp
@@ -1870,7 +1870,7 @@ void dPlayerControl_SetKillTimer(PlayerControl* __this, float time, MethodInfo* 
 void dPlayerControl_CheckColor(PlayerControl* __this, uint8_t bodyColor, MethodInfo* method) {
     if (State.ShowHookLogs) Log.HookDebug("Hook dPlayerControl_CheckColor executed", false);
 
-    if (!State.AllowPreferedColor) {
+    if (!State.AllowPreferredColor) {
         PlayerControl_CheckColor(__this, bodyColor, method);
         return;
     }

--- a/hooks/PlayerControl.cpp
+++ b/hooks/PlayerControl.cpp
@@ -1563,11 +1563,16 @@ void dNetworkedPlayerInfo_Serialize(NetworkedPlayerInfo* __this, MessageWriter* 
 
 void dNetworkedPlayerInfo_Deserialize(NetworkedPlayerInfo* __this, MessageReader* reader, bool initialState, MethodInfo* method) {
     if (State.ShowHookLogs) Log.HookDebug("Hook dNetworkedPlayerInfo_Deserialize executed", false);
+
     std::string friendCode = convert_from_string(__this->fields.FriendCode);
     uint8_t id = __this->fields.PlayerId;
+
     if (std::find(State.BlacklistFriendCodes.begin(), State.BlacklistFriendCodes.end(), friendCode) != State.BlacklistFriendCodes.end()) {
         if (State.Enable_SMAC) {
             std::string name = RemoveHtmlTags(convert_from_string(NetworkedPlayerInfo_get_PlayerName(__this, NULL)));
+            auto* notifier = (NotificationPopper*)Game::HudManager.GetInstance()->fields.Notifier;
+            float spacingBackup = notifier->fields.spacingY;
+
             switch (IsHost() ? State.SMAC_HostPunishment : State.SMAC_Punishment) {
             case 0:
                 break;
@@ -1576,27 +1581,38 @@ void dNetworkedPlayerInfo_Deserialize(NetworkedPlayerInfo* __this, MessageReader
                 ChatController_AddChat(Game::HudManager.GetInstance()->fields.Chat, GetPlayerControlById(id), convert_to_string(message), false, NULL);
                 break;
             }
-            case 2:
-            {
+            case 2: {
                 String* newName = convert_to_string(name + " has been kicked by <#ff006c>SickoMenu</color> <#9ef>Anticheat</color>! Reason: Blacklisted<size=0>");
                 if (IsHost()) {
-                    PlayerControl_CmdCheckName(GetPlayerControlById(id), newName, NULL);
-                    InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), GetPlayerControlById(id)->fields._.OwnerId, false, NULL);
+                    notifier->fields.spacingY = spacingBackup += 0.05f;
+                    NotificationPopper_AddDisconnectMessage(notifier, newName, nullptr);
+                    notifier->fields.spacingY = spacingBackup;
+
+                    State.SMAC_PunishedPlayers.insert(__this->fields.PlayerId);
+
+                    State.IgnoreOriginalInit_NotificationPopper = true;
+                    InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), __this->fields._.OwnerId, false, NULL);
                 }
                 break;
             }
-            case 3:
-            {
+            case 3: {
                 String* newName = convert_to_string(name + " has been banned by <#ff006c>SickoMenu</color> <#9ef>Anticheat</color>! Reason: Blacklisted<size=0>");
                 if (IsHost()) {
-                    PlayerControl_CmdCheckName(GetPlayerControlById(id), newName, NULL);
-                    InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), GetPlayerControlById(id)->fields._.OwnerId, true, NULL);
+                    notifier->fields.spacingY = spacingBackup += 0.05f;
+                    NotificationPopper_AddDisconnectMessage(notifier, newName, nullptr);
+                    notifier->fields.spacingY = spacingBackup;
+
+                    State.SMAC_PunishedPlayers.insert(__this->fields.PlayerId);
+
+                    State.IgnoreOriginalInit_NotificationPopper = true;
+                    InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), __this->fields._.OwnerId, false, NULL);
                 }
                 break;
             }
             }
         }
     }
+
     NetworkedPlayerInfo_Deserialize(__this, reader, initialState, NULL);
 }
 

--- a/hooks/_hooks.cpp
+++ b/hooks/_hooks.cpp
@@ -302,6 +302,8 @@ void DetourInitilization() {
 	HOOKFUNC(PlayerVoteArea_SetCosmetics);
 	HOOKFUNC(PlayerControl_SetKillTimer);
 	HOOKFUNC(VentilationSystem_UpdateSystem);
+	HOOKFUNC(InnerNetClient_SetEndpoint);
+	HOOKFUNC(NotificationPopper_AddDisconnectMessage);
 
 	if (!HookFunction(&(PVOID&)oPresent, dPresent, "D3D_PRESENT_FUNCTION")) return;
 
@@ -515,6 +517,8 @@ void DetourUninitialization()
 	UNHOOKFUNC(PlayerVoteArea_SetCosmetics);
 	UNHOOKFUNC(PlayerControl_SetKillTimer);
 	UNHOOKFUNC(VentilationSystem_UpdateSystem);
+	UNHOOKFUNC(InnerNetClient_SetEndpoint);
+	UNHOOKFUNC(NotificationPopper_AddDisconnectMessage);
 
 	if (DetourDetach(&(PVOID&)oPresent, dPresent) != 0) return;
 

--- a/hooks/_hooks.cpp
+++ b/hooks/_hooks.cpp
@@ -304,6 +304,7 @@ void DetourInitilization() {
 	HOOKFUNC(VentilationSystem_UpdateSystem);
 	HOOKFUNC(InnerNetClient_SetEndpoint);
 	HOOKFUNC(NotificationPopper_AddDisconnectMessage);
+	HOOKFUNC(PlayerControl_CheckColor);
 
 	if (!HookFunction(&(PVOID&)oPresent, dPresent, "D3D_PRESENT_FUNCTION")) return;
 
@@ -519,6 +520,7 @@ void DetourUninitialization()
 	UNHOOKFUNC(VentilationSystem_UpdateSystem);
 	UNHOOKFUNC(InnerNetClient_SetEndpoint);
 	UNHOOKFUNC(NotificationPopper_AddDisconnectMessage);
+	UNHOOKFUNC(PlayerControl_CheckColor);
 
 	if (DetourDetach(&(PVOID&)oPresent, dPresent) != 0) return;
 

--- a/hooks/_hooks.h
+++ b/hooks/_hooks.h
@@ -221,3 +221,6 @@ void dVentilationSystem_UpdateSystem(VentilationSystem* __this, PlayerControl* p
 void ApplyHostPreset(const Settings::HostPreset& p);
 void RequestApplyHostPreset(int idx);
 void ApplyCosmeticPreset(const Settings::CosmeticPreset& p);
+
+void dInnerNetClient_SetEndpoint(InnerNetClient* __this, String* addr, uint16_t port, bool dtls, MethodInfo* method);
+void dNotificationPopper_AddDisconnectMessage(NotificationPopper* __this, String* item, MethodInfo* method);

--- a/hooks/_hooks.h
+++ b/hooks/_hooks.h
@@ -224,3 +224,4 @@ void ApplyCosmeticPreset(const Settings::CosmeticPreset& p);
 
 void dInnerNetClient_SetEndpoint(InnerNetClient* __this, String* addr, uint16_t port, bool dtls, MethodInfo* method);
 void dNotificationPopper_AddDisconnectMessage(NotificationPopper* __this, String* item, MethodInfo* method);
+void dPlayerControl_CheckColor(PlayerControl* __this, uint8_t bodyColor, MethodInfo* method);

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -526,6 +526,8 @@ void Settings::Load() {
         JSON_TRYGET("AutoHostRole", this->AutoHostRole);
         JSON_TRYGET("HostRoleToSet", this->HostRoleToSet);
 
+		JSON_TRYGET("AllowPreferedColor", this->AllowPreferedColor);
+
         JSON_TRYGET("WhitelistFriendCodes", this->WhitelistFriendCodes);
         JSON_TRYGET("BlacklistFriendCodes", this->BlacklistFriendCodes);
         JSON_TRYGET("WarnedFriendCodes", this->WarnedFriendCodes);
@@ -1184,6 +1186,8 @@ void Settings::Save() {
                 { "BypassVisualTasks", this->BypassVisualTasks },
                 { "AutoHostRole", this->AutoHostRole },
                 { "HostRoleToSet", this->HostRoleToSet },
+
+				{ "AllowPreferedColor", this->AllowPreferedColor},
 
                 { "WhitelistFriendCodes", this->WhitelistFriendCodes },
                 { "BlacklistFriendCodes", this->BlacklistFriendCodes },

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -526,7 +526,7 @@ void Settings::Load() {
         JSON_TRYGET("AutoHostRole", this->AutoHostRole);
         JSON_TRYGET("HostRoleToSet", this->HostRoleToSet);
 
-		JSON_TRYGET("AllowPreferedColor", this->AllowPreferedColor);
+		JSON_TRYGET("AllowPreferredColor", this->AllowPreferredColor);
 
         JSON_TRYGET("WhitelistFriendCodes", this->WhitelistFriendCodes);
         JSON_TRYGET("BlacklistFriendCodes", this->BlacklistFriendCodes);
@@ -1187,7 +1187,7 @@ void Settings::Save() {
                 { "AutoHostRole", this->AutoHostRole },
                 { "HostRoleToSet", this->HostRoleToSet },
 
-				{ "AllowPreferedColor", this->AllowPreferedColor},
+				{ "AllowPreferredColor", this->AllowPreferredColor},
 
                 { "WhitelistFriendCodes", this->WhitelistFriendCodes },
                 { "BlacklistFriendCodes", this->BlacklistFriendCodes },

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -101,6 +101,13 @@ void Settings::Load() {
         JSON_TRYGET("FakePsnId", this->FakePsnId);
         JSON_TRYGET("SpoofXboxId", this->SpoofXboxId);
         JSON_TRYGET("FakeXboxId", this->FakeXboxId);
+        JSON_TRYGET("SpoofPlName", this->SpoofPlName);
+        JSON_TRYGET("FakePlName", this->FakePlName);
+        JSON_TRYGET("UseCustomServer", this->UseCustomServer);
+        JSON_TRYGET("FakePlName", this->FakePlName);
+        JSON_TRYGET("CustomServerIp", this->CustomServerIp);
+        JSON_TRYGET("CustomServerPort", this->CustomServerPort);
+        JSON_TRYGET("ForceDTLS", this->ForceDTLS);
         JSON_TRYGET("SpoofGuestAccount", this->SpoofGuestAccount);
         // JSON_TRYGET("SpoofAUVersion_", this->SpoofAUVersion); // putting an underscore to reset version spoofing, remove to reset again
         // JSON_TRYGET("FakeAUVersion_", this->FakeAUVersion);
@@ -371,6 +378,7 @@ void Settings::Load() {
         JSON_TRYGET("BetterChatNotifications", this->BetterChatNotifications);
         JSON_TRYGET("BetterLobbyCodeInput", this->BetterLobbyCodeInput);
         JSON_TRYGET("BetterMessageSounds", this->BetterMessageSounds);
+        JSON_TRYGET("ExtendedNotifications", this->ExtendedNotifications);
         JSON_TRYGET("NoClip", this->NoClip);
         JSON_TRYGET("KillInLobbies", this->KillInLobbies);
         JSON_TRYGET("KillInVanish", this->KillInVanish);
@@ -777,6 +785,13 @@ void Settings::Save() {
                 { "FakePsnId", this->FakePsnId },
                 { "SpoofXboxId", this->SpoofXboxId },
                 { "FakeXboxId", this->FakeXboxId },
+                { "SpoofPlName", this->SpoofPlName},
+                { "FakePlName", this->FakePlName},
+                { "UseCustomServer", this->UseCustomServer},
+                { "CustomServerIp", this->CustomServerIp},
+                { "CustomServerPort", this->CustomServerPort},
+                { "ForceDTLS", this->ForceDTLS},
+
                 { "SpoofGuestAccount", this->SpoofGuestAccount },
                 // { "SpoofAUVersion_", this->SpoofAUVersion }, // putting an underscore to reset version spoofing, remove to reset again
                 // { "FakeAUVersion_", this->FakeAUVersion },
@@ -1044,6 +1059,7 @@ void Settings::Save() {
                 { "BetterChatNotifications", this->BetterChatNotifications },
                 { "BetterLobbyCodeInput", this->BetterLobbyCodeInput },
                 { "BetterMessageSounds", this->BetterMessageSounds },
+                { "ExtendedNotifications", this->ExtendedNotifications },
                 { "NoClip", this->NoClip },
                 { "KillInLobbies", this->KillInLobbies },
                 { "KillInVanish", this->KillInVanish },

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -726,7 +726,7 @@ public:
     bool AutoHostRole = false;
     RoleType HostRoleToSet = RoleType::Impostor;
 
-    bool AllowPreferedColor = false;
+    bool AllowPreferredColor = false;
 
     bool murderLoop = false;
     bool suicideLoop = false;

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -726,6 +726,8 @@ public:
     bool AutoHostRole = false;
     RoleType HostRoleToSet = RoleType::Impostor;
 
+    bool AllowPreferedColor = false;
+
     bool murderLoop = false;
     bool suicideLoop = false;
     bool farmLoop = false;

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -76,6 +76,12 @@ public:
     int FakePlatform = 0;
     uint64_t FakePsnId = 0;
     uint64_t FakeXboxId = 0;
+    bool SpoofPlName = false;
+    std::string FakePlName = "TESTNAME";
+    bool UseCustomServer = false;
+    std::string CustomServerIp = "";
+    uint16_t CustomServerPort = 22023;
+    bool ForceDTLS = false;
     bool SpoofGuestAccount = false;
     bool SpoofModdedHost = false;
     bool SpoofAUVersion = false;
@@ -364,6 +370,7 @@ public:
     bool BetterChatNotifications = false;
     bool BetterLobbyCodeInput = false;
     bool BetterMessageSounds = false;
+    bool ExtendedNotifications = false;
     AudioClip* MessageSound = NULL;
 
     PlayerSelection selectedPlayer;
@@ -787,6 +794,8 @@ public:
 
     std::vector<std::string> LockedNames = {};
 
+    std::unordered_set<uint8_t> SMAC_PunishedPlayers;
+
     std::string lol = "";
     bool ProGamer = false;
     bool KeybindsBeingEdited = false;
@@ -920,6 +929,8 @@ public:
     {"Playstation (Console)", true},
     {"Unknown", true}
     };
+
+    bool IgnoreOriginalInit_NotificationPopper = true;
 
     void Load();
     void Save();

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -1,4 +1,4 @@
-﻿#include "pch-il2cpp.h"
+#include "pch-il2cpp.h"
 #include "utility.h"
 #include "state.hpp"
 #include "game.h"
@@ -1955,102 +1955,86 @@ static std::string SMAC_GetReasonCategory(const std::string& reason) {
 
 void SMAC_OnCheatDetected(PlayerControl* pCtrl, std::string reason) {
     if (!State.Enable_SMAC) return;
-    if (reason == "Overloading" && !(IsHost() && State.SMAC_HostPunishment >= 2)) return; // Don't spam logs for overloading, that causes overload as well
-    if (pCtrl == *Game::pLocalPlayer || (!IsInLobby() && !IsInMultiplayerGame())) return; // Avoid detecting yourself and practice mode dummies
-    if (reason == "Bad Sabotage" && !IsHost()) return; // Without host, we cannot detect who sent UpdateSystem rpc properly
+    if (reason == "Overloading" && !(IsHost() && State.SMAC_HostPunishment >= 2)) return; // Don't spam logs for overloading
+    if (pCtrl == *Game::pLocalPlayer || (!IsInLobby() && !IsInMultiplayerGame())) return;
+    if (reason == "Bad Sabotage" && !IsHost()) return;
 
     static std::unordered_map<std::string, std::chrono::steady_clock::time_point> smacLastFlagTime;
     std::string smacFlagKey = std::to_string(pCtrl->fields.PlayerId) + "|" + reason;
     auto smacNow = std::chrono::steady_clock::now();
     auto smacFlagIt = smacLastFlagTime.find(smacFlagKey);
-    if (smacFlagIt != smacLastFlagTime.end() && std::chrono::duration<float>(smacNow - smacFlagIt->second).count() < 3.0f) return; // Don't re-flag the same player for the same reason more than once every 3s
+    if (smacFlagIt != smacLastFlagTime.end() && std::chrono::duration<float>(smacNow - smacFlagIt->second).count() < 3.0f) return;
     smacLastFlagTime[smacFlagKey] = smacNow;
 
     auto pData = GetPlayerData(pCtrl);
-    std::string name = RemoveHtmlTags(convert_from_string(GetPlayerOutfit(GetPlayerData(pCtrl))->fields.PlayerName));
-    if (name == "") name = convert_from_string(InnerNetClient_GetClientFromCharacter((InnerNetClient*)(*Game::pAmongUsClient), pCtrl, NULL)->fields.PlayerName);
-    if (name == "") name = "<#b0f>[Unknown]</color>";
+    std::string name = RemoveHtmlTags(convert_from_string(GetPlayerOutfit(pData)->fields.PlayerName));
+    if (name.empty()) name = convert_from_string(InnerNetClient_GetClientFromCharacter((InnerNetClient*)(*Game::pAmongUsClient), pCtrl, NULL)->fields.PlayerName);
+    if (name.empty()) name = "<#b0f>[Unknown]</color>";
 
     std::string fc = convert_from_string(pData->fields.FriendCode);
     auto it = std::find(State.WhitelistFriendCodes.begin(), State.WhitelistFriendCodes.end(), fc);
-    if (fc != "" && State.SMAC_IgnoreWhitelist && it != State.WhitelistFriendCodes.end()) return;
-    if (fc != "" && State.SMAC_AddToBlacklist) {
+    if (!fc.empty() && State.SMAC_IgnoreWhitelist && it != State.WhitelistFriendCodes.end()) return;
+    if (!fc.empty() && State.SMAC_AddToBlacklist) {
         if (it != State.WhitelistFriendCodes.end()) State.WhitelistFriendCodes.erase(it);
-        AddToBlacklist(fc); 
+        State.BlacklistFriendCodes.push_back(fc);
+        State.Save();
     }
 
-    std::string smacCategory = SMAC_GetReasonCategory(reason);
-    int punishmentLevel = IsHost() ? State.SMAC_HostPunishment : State.SMAC_Punishment;
-    if (!smacCategory.empty()) {
-        auto override = IsHost() ? State.SMAC_ReasonPunishmentOverrideHost : State.SMAC_ReasonPunishmentOverride;
-        
-        auto overrideIt = override.find(smacCategory);
-        if (overrideIt != override.end())
-            punishmentLevel = overrideIt->second;
-    }
+    auto* notifier = (NotificationPopper*)Game::HudManager.GetInstance()->fields.Notifier;
+    float spacingBackup = notifier->fields.spacingY;
 
-    int maxPunishmentLevel = IsHost() ? 3 : 1;
-    punishmentLevel = std::clamp(punishmentLevel, 0, maxPunishmentLevel);
+    int punishment = IsHost() ? State.SMAC_HostPunishment : State.SMAC_Punishment;
 
-    if (IsHost()) {
-        switch (punishmentLevel) {
-        case 0:
-            LOG_INFO((name + " has been detected by SickoMenu Anticheat! Reason: " + reason).c_str());
-            break;
-        case 1: {
-            auto realOutfit = GetPlayerOutfit(pData);
-            Color32&& nameColor = GetPlayerColor(realOutfit->fields.ColorId);
-            const std::vector<std::string> COLORS = { "Red", "Blue", "Green", "Pink", "Orange", "Yellow", "Black", "White", "Purple", "Brown", "Cyan", "Lime", "Maroon", "Rose", "Banana", "Gray", "Tan", "Coral" };
-            std::string colorText = State.CustomGameTheme ? std::format("<#{:02x}{:02x}{:02x}>",
-                int(State.GameTextColor.x * 255), int(State.GameTextColor.y * 255), int(State.GameTextColor.z * 255)) :
-                State.DarkMode ? "<#fff>" : "<#000>";
-            std::string cheaterMessage = std::format("<size=90%>{}Player <#{:02x}{:02x}{:02x}{:02x}>{}</color>{} has done an unauthorized action</color>\n<b>{}</b></size>",
-                colorText, nameColor.r, nameColor.g, nameColor.b, nameColor.a, name,
-                IsColorBlindMode() ? (realOutfit->fields.ColorId >= 0 && realOutfit->fields.ColorId < (int32_t)COLORS.size() ?
-                    " (" + COLORS[realOutfit->fields.ColorId] + ")" : " (Fortegreen)") : "", reason);
-            //ChatController_AddChat(Game::HudManager.GetInstance()->fields.Chat, pCtrl, convert_to_string(cheaterMessage), false, NULL);
-            ChatController_AddChatWarning(Game::HudManager.GetInstance()->fields.Chat, convert_to_string(cheaterMessage), NULL);
-            break;
-        }
-        case 2:
-        {
-            String* newName = convert_to_string(name + " <#fff>has been kicked by <#ff006c>SickoMenu</color> <#9ef>Anticheat</color>! Reason: </color><#f00><b>" + reason + "</b></color><size=0>");
-            if (name.find(" by SickoMenu Anticheat! Reason: ") == std::string::npos)
-                GetPlayerOutfit(GetPlayerData(pCtrl))->fields.PlayerName = newName; // Set name for yourself as it doesn't show up fast enough for others
-            InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), pCtrl->fields._.OwnerId, false, NULL);
-            break;
-        }
-        case 3:
-        {
-            String* newName = convert_to_string(name + " <#fff>has been banned by <#ff006c>SickoMenu</color> <#9ef>Anticheat</color>! Reason: </color><#f00><b>" + reason + "</b></color><size=0>");
-            if (name.find(" by SickoMenu Anticheat! Reason: ") == std::string::npos)
-                GetPlayerOutfit(GetPlayerData(pCtrl))->fields.PlayerName = newName; // Set name for yourself as it doesn't show up fast enough for others
-            InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), pCtrl->fields._.OwnerId, true, NULL);
-            break;
-        }
-        }
+    switch (punishment) {
+    case 0:
+        LOG_INFO((name + " has been detected by SickoMenu Anticheat! Reason: " + reason).c_str());
+        break;
+    case 1:
+    {
+        auto realOutfit = GetPlayerOutfit(pData);
+        Color32&& nameColor = GetPlayerColor(realOutfit->fields.ColorId);
+        const std::vector<std::string> COLORS = { "Red", "Blue", "Green", "Pink", "Orange", "Yellow", "Black", "White", "Purple", "Brown", "Cyan", "Lime", "Maroon", "Rose", "Banana", "Gray", "Tan", "Coral" };
+
+        std::string colorText = State.CustomGameTheme ? std::format("<#{:02x}{:02x}{:02x}>",
+            int(State.GameTextColor.x * 255), int(State.GameTextColor.y * 255), int(State.GameTextColor.z * 255)) :
+            State.DarkMode ? "<#fff>" : "<#000>";
+
+        std::string cheaterMessage = std::format("<size=90%>{}Player <#{:02x}{:02x}{:02x}{:02x}>{}</color>{} has done an unauthorized action</color>\n<b>{}</b></size>",
+            colorText, nameColor.r, nameColor.g, nameColor.b, nameColor.a, name,
+            IsColorBlindMode() ? (realOutfit->fields.ColorId >= 0 && realOutfit->fields.ColorId < (int32_t)COLORS.size() ?
+                " (" + COLORS[realOutfit->fields.ColorId] + ")" : " (Fortegreen)") : "", reason);
+
+        ChatController_AddChatWarning(Game::HudManager.GetInstance()->fields.Chat, convert_to_string(cheaterMessage), NULL);
+        break;
     }
-    else {
-        switch (punishmentLevel) {
-        case 0:
-            LOG_INFO((name + " has been detected by SickoMenu Anticheat! Reason: " + reason).c_str());
-            break;
-        case 1: {
-            auto realOutfit = GetPlayerOutfit(pData);
-            Color32&& nameColor = GetPlayerColor(realOutfit->fields.ColorId);
-            const std::vector<std::string> COLORS = { "Red", "Blue", "Green", "Pink", "Orange", "Yellow", "Black", "White", "Purple", "Brown", "Cyan", "Lime", "Maroon", "Rose", "Banana", "Gray", "Tan", "Coral" };
-            std::string colorText = State.CustomGameTheme ? std::format("<#{:02x}{:02x}{:02x}>",
-                int(State.GameTextColor.x * 255), int(State.GameTextColor.y * 255), int(State.GameTextColor.z * 255)) :
-                State.DarkMode ? "<#fff>" : "<#000>";
-            std::string cheaterMessage = std::format("<size=90%>{}Player <#{:02x}{:02x}{:02x}{:02x}>{}</color>{} has done an unauthorized action</color>\n<b>{}</b></size>",
-                colorText, nameColor.r, nameColor.g, nameColor.b, nameColor.a, name,
-                IsColorBlindMode() ? (realOutfit->fields.ColorId >= 0 && realOutfit->fields.ColorId < (int32_t)COLORS.size() ?
-                    " (" + COLORS[realOutfit->fields.ColorId] + ")" : " (Fortegreen)") : "", reason);
-            //ChatController_AddChat(Game::HudManager.GetInstance()->fields.Chat, pCtrl, convert_to_string(cheaterMessage), false, NULL);
-            ChatController_AddChatWarning(Game::HudManager.GetInstance()->fields.Chat, convert_to_string(cheaterMessage), NULL);
-            break;
-        }
-        }
+    case 2:
+    {
+        String* newName = convert_to_string(name + " <#fff>has been kicked by <#ff006c>SickoMenu</color> <#9ef>Anticheat</color>! Reason: </color><#f00><b>" + reason + "</b></color><size=0>");
+
+        notifier->fields.spacingY = spacingBackup += 0.05f;
+        NotificationPopper_AddDisconnectMessage(notifier, newName, nullptr);
+        notifier->fields.spacingY = spacingBackup;
+
+        State.SMAC_PunishedPlayers.insert(pCtrl->fields.PlayerId);
+
+        State.IgnoreOriginalInit_NotificationPopper = true;
+        InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), pCtrl->fields._.OwnerId, false, NULL);
+        break;
+    }
+    case 3:
+    {
+        String* newName = convert_to_string(name + " <#fff>has been banned by <#ff006c>SickoMenu</color> <#9ef>Anticheat</color>! Reason: </color><#f00><b>" + reason + "</b></color><size=0>");
+
+        notifier->fields.spacingY = spacingBackup += 0.05f;
+        NotificationPopper_AddDisconnectMessage(notifier, newName, nullptr);
+        notifier->fields.spacingY = spacingBackup;
+
+        State.SMAC_PunishedPlayers.insert(pCtrl->fields.PlayerId);
+
+        State.IgnoreOriginalInit_NotificationPopper = true;
+        InnerNetClient_KickPlayer((InnerNetClient*)(*Game::pAmongUsClient), pCtrl->fields._.OwnerId, true, NULL);
+        break;
+    }
     }
 }
 
@@ -2907,5 +2891,148 @@ void GeneratePlatformId() {
         State.FakePsnId = GeneratePsnId();
         State.SpoofPsnId = true;
         State.Save();
+    }
+}
+
+std::string GetDisconnectReasonString(DisconnectReasons__Enum reason) {
+    switch (reason) {
+    case DisconnectReasons__Enum::ExitGame:
+        return "ExitGame";
+
+    case DisconnectReasons__Enum::GameFull:
+        return "GameFull";
+
+    case DisconnectReasons__Enum::GameStarted:
+        return "GameStarted";
+
+    case DisconnectReasons__Enum::GameNotFound:
+        return "GameNotFound";
+
+    case DisconnectReasons__Enum::IncorrectVersion:
+        return "IncorrectVersion";
+
+    case DisconnectReasons__Enum::Banned:
+        return "Banned";
+
+    case DisconnectReasons__Enum::Kicked:
+        return "Kicked";
+
+    case DisconnectReasons__Enum::Custom:
+        return "Custom";
+
+    case DisconnectReasons__Enum::InvalidName:
+        return "InvalidName";
+
+    case DisconnectReasons__Enum::Hacking:
+        return "Hacking";
+
+    case DisconnectReasons__Enum::NotAuthorized:
+        return "NotAuthorized";
+
+    case DisconnectReasons__Enum::ConnectionLimit:
+        return "ConnectionLimit";
+
+    case DisconnectReasons__Enum::Destroy:
+        return "Destroy";
+
+    case DisconnectReasons__Enum::Error:
+        return "Error";
+
+    case DisconnectReasons__Enum::IncorrectGame:
+        return "IncorrectGame";
+
+    case DisconnectReasons__Enum::ServerRequest:
+        return "ServerRequest";
+
+    case DisconnectReasons__Enum::ServerFull:
+        return "ServerFull";
+
+    case DisconnectReasons__Enum::MismatchedVersion:
+        return "MismatchedVersion";
+
+    case DisconnectReasons__Enum::InternalPlayerMissing:
+        return "InternalPlayerMissing";
+
+    case DisconnectReasons__Enum::InternalNonceFailure:
+        return "InternalNonceFailure";
+
+    case DisconnectReasons__Enum::InternalConnectionToken:
+        return "InternalConnectionToken";
+
+    case DisconnectReasons__Enum::PlatformLock:
+        return "PlatformLock";
+
+    case DisconnectReasons__Enum::LobbyInactivity:
+        return "LobbyInactivity";
+
+    case DisconnectReasons__Enum::MatchmakerInactivity:
+        return "MatchmakerInactivity";
+
+    case DisconnectReasons__Enum::InvalidGameOptions:
+        return "InvalidGameOptions";
+
+    case DisconnectReasons__Enum::NoServersAvailable:
+        return "NoServersAvailable";
+
+    case DisconnectReasons__Enum::QuickmatchDisabled:
+        return "QuickmatchDisabled";
+
+    case DisconnectReasons__Enum::TooManyGames:
+        return "TooManyGames";
+
+    case DisconnectReasons__Enum::QuickchatLock:
+        return "QuickchatLock";
+
+    case DisconnectReasons__Enum::MatchmakerFull:
+        return "MatchmakerFull";
+
+    case DisconnectReasons__Enum::Sanctions:
+        return "Sanctions";
+
+    case DisconnectReasons__Enum::ServerError:
+        return "ServerError";
+
+    case DisconnectReasons__Enum::SelfPlatformLock:
+        return "SelfPlatformLock";
+
+    case DisconnectReasons__Enum::DuplicateConnectionDetected:
+        return "DuplicateConnectionDetected";
+
+    case DisconnectReasons__Enum::TooManyRequests:
+        return "TooManyRequests";
+
+    case DisconnectReasons__Enum::FocusLostBackground:
+        return "FocusLostBackground";
+
+    case DisconnectReasons__Enum::IntentionalLeaving:
+        return "IntentionalLeaving";
+
+    case DisconnectReasons__Enum::FocusLost:
+        return "FocusLost";
+
+    case DisconnectReasons__Enum::NewConnection:
+        return "NewConnection";
+
+    case DisconnectReasons__Enum::PlatformParentalControlsBlock:
+        return "PlatformParentalControlsBlock";
+
+    case DisconnectReasons__Enum::PlatformUserBlock:
+        return "PlatformUserBlock";
+
+    case DisconnectReasons__Enum::PlatformFailedToGetUserBlock:
+        return "PlatformFailedToGetUserBlock";
+
+    case DisconnectReasons__Enum::ServerNotFound:
+        return "ServerNotFound";
+
+    case DisconnectReasons__Enum::ClientTimeout:
+        return "ClientTimeout";
+
+    case DisconnectReasons__Enum::ErrorAuthNonceFailure:
+        return "ErrorAuthNonceFailure";
+
+    case DisconnectReasons__Enum::Unknown:
+    default:
+        return "Unknown";
     }
 }

--- a/user/utility.h
+++ b/user/utility.h
@@ -247,6 +247,7 @@ il2cpp::Array<Camera__Array> GetAllCameras();
 il2cpp::List<List_1_InnerNet_ClientData_> GetAllClients();
 Vector2 GetSpawnLocation(Game::PlayerId playerId, int numPlayer, bool initialSpawn);
 void GeneratePlatformId();
+std::string GetDisconnectReasonString(DisconnectReasons__Enum reason);
 bool IsAirshipSpawnLocation(const Vector2& vec);
 Vector2 Rotate(const Vector2& vec, float degrees);
 bool Equals(const Vector2& vec1, const Vector2& vec2);


### PR DESCRIPTION
## Spoofing:
- Change PlatformName
- Use custom server settings:
  - Change server IP
  - Change server Port
- Force DTLS

## Extended Notifications (Self → Utils):
- Player joined
  - Example: ``Joined: {name} | {friendcode}``
- Player left (more detailed reasons)
  - Example: ``Left: {name} by reason: {reason}``

## Anticheat notification fixes:
- Added a method blocking initialization the original method of NotificationPopper
- Instead of using local name changer, we'll just use NotificationPopper
- Y shift so that the long (consisting of 3 lines) notifications doesn't overlap with the next one

## Misc
- Added PlatformName display for players
- Added warning before enabling "Custom Server Settings"
- Added IP:Port for "Show Lobby Info" in matchmaker

UPD:
- Added feature "Allow Join with Prefered Color" in host tab