### PR TITLE
Fix Modify Start Countdown lag and scroll-to-zoom triggering while menu is open

### DIFF
--- a/gui/tabs/host_tab.cpp
+++ b/gui/tabs/host_tab.cpp
@@ -414,9 +414,20 @@ namespace HostTab {
                 if (ToggleButton("Modify Start Countdown", &State.ModifyStartCountdown))
                     State.Save();
 
-                if (State.ModifyStartCountdown && ImGui::InputInt("Time", &State.StartCountdown)) {
-                    State.StartCountdown = std::clamp(State.StartCountdown, 1, !State.SafeMode ? 127 : 5);
-                    State.Save();
+                if (State.ModifyStartCountdown) {
+                    static int countdownBuf = State.StartCountdown;
+                    static bool countdownEditing = false;
+                    if (!countdownEditing) countdownBuf = State.StartCountdown;
+                    ImGui::InputInt("Countdown Time", &countdownBuf);
+                    countdownEditing = ImGui::IsItemActive();
+                    if (ImGui::IsItemDeactivatedAfterEdit()) {
+                        int clamped = std::clamp(countdownBuf, 1, !State.SafeMode ? 127 : 5);
+                        if (clamped != State.StartCountdown) {
+                            State.StartCountdown = clamped;
+                            State.Save();
+                        }
+                        countdownBuf = State.StartCountdown;
+                    }
                 }
 
                 if (ToggleButton("Disable Meetings", &State.DisableMeetings))

--- a/gui/tabs/host_tab.cpp
+++ b/gui/tabs/host_tab.cpp
@@ -418,7 +418,7 @@ namespace HostTab {
                     static int countdownBuf = State.StartCountdown;
                     static bool countdownEditing = false;
                     if (!countdownEditing) countdownBuf = State.StartCountdown;
-                    ImGui::InputInt("Countdown Time", &countdownBuf);
+                    ImGui::InputInt("Time", &countdownBuf);
                     countdownEditing = ImGui::IsItemActive();
                     if (ImGui::IsItemDeactivatedAfterEdit()) {
                         int clamped = std::clamp(countdownBuf, 1, !State.SafeMode ? 127 : 5);

--- a/hooks/DirectX.cpp
+++ b/hooks/DirectX.cpp
@@ -160,7 +160,7 @@ LRESULT __stdcall dWndProc(const HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
     if ((IsInGame() || IsInLobby()) && Game::HudManager.GetInstance()->fields.Chat != NULL && shouldKeybindsActivate) {
         auto chatState = Game::HudManager.GetInstance()->fields.Chat->fields.state;
         bool chatOpen = chatState == ChatControllerState__Enum::Open || chatState == ChatControllerState__Enum::Opening || chatState == ChatControllerState__Enum::Closing;
-        bool isScrollModifierAllowed = !chatOpen && !State.InMeeting && State.EnableZoom_ScrollZoom;
+        bool isScrollModifierAllowed = !chatOpen && !State.InMeeting && !State.ShowMenu && State.EnableZoom_ScrollZoom;
         bool isShifted = ImGui::IsKeyDown(VK_SHIFT) || ImGui::IsKeyDown(VK_LSHIFT) || ImGui::IsKeyDown(VK_RSHIFT);
 
         if (!isShifted && isScrollModifierAllowed && State.EnableZoom && (IsInGame() || IsInLobby())) {


### PR DESCRIPTION
1. Modify Start Countdown causing lag on invalid input
Entering a value outside the valid range (0, or 6+ with safe mode max of 5) in the countdown Time field caused heavy lag while typing/editing the clamp only ran inside the InputInt changed-check which its against imgui internal edit buffer every frame the widget was focused with an out-of-range value it registered as "changed" again spamming a full config write via State.Save() every single frame 
2. Scroll-to-zoom active while menu is open
with Scroll to Zoom enabled scrolling the mouse wheel while the menu was open (e.g scrolling the Player tab (which has no scroll bar of its own) also zoomed the in-game camera, since the scroll handler had no check for whether the menu was open