### PR TITLE
New smac detection: "Abnormal Movements" (Teleporting)

### DIFF
--- a/appdata/il2cpp-functions.h
+++ b/appdata/il2cpp-functions.h
@@ -516,3 +516,5 @@ DO_APP_FUNC(void, KillButton_DoClick, (KillButton* __this, MethodInfo* method), 
 DO_APP_FUNC(void, VentButton_DoClick, (VentButton* __this, MethodInfo* method), "Assembly-CSharp, System.Void VentButton::DoClick()");
 
 DO_APP_FUNC(void, InnerNetClient_SetEndpoint, (InnerNetClient* __this, String* addr, uint16_t port, bool dtls, MethodInfo* method), "Assembly-CSharp, System.Void InnerNet.InnerNetClient::SetEndpoint(System.String, System.UInt16, System.Boolean)");
+
+DO_APP_FUNC(void, CustomNetworkTransform_HandleRpc, (CustomNetworkTransform* __this, uint8_t callId, MessageReader* reader, MethodInfo* method), "Assembly-CSharp, System.Void CustomNetworkTransform::HandleRpc(System.Byte, Hazel.MessageReader)");

--- a/gui/tabs/game_tab.cpp
+++ b/gui/tabs/game_tab.cpp
@@ -739,7 +739,7 @@ namespace GameTab {
                     "Setting Tasks", "Abnormal Murders", "Abnormal Shapeshift", "Abnormal Vanish",
                     "Abnormal Meetings/Body Reports", "Abnormal Venting", "Abnormal Chat",
                     "Abnormal Task Completion", "Abnormal Sabotages", "Abnormal Player Levels",
-                    "Abnormal Friendcode", "Blocked Words", "Blocked Start Words","Blacklisted Players",
+                    "Abnormal Friendcode", "Abnormal Movements",  "Blocked Words", "Blocked Start Words", "Blacklisted Players",
                 };
                 static int selectedCategory = 0;
 
@@ -879,6 +879,7 @@ namespace GameTab {
                 ImGui::InputInt("Level >=", &State.SMAC_HighLevel);
                 ImGui::InputInt("Level <=", &State.SMAC_LowLevel);
             }
+            if (ToggleButton("Abnormal Movements", &State.SMAC_CheckTeleports)) State.Save();
             if (ToggleButton("Blocked Words", &State.SMAC_CheckBadWords)) State.Save();
             if (State.SMAC_CheckBadWords) {
                 static const std::vector<const char*> SMAC_DETECTION_MODES = { "Default Detection", "Strict Detection" };

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -1715,38 +1715,81 @@ bool bogusTransformSnap(PlayerSelection& _player, Vector2 newPosition)
     return true; //We have ruled out all possible scenarios.  Off with his head!
 }
 
-void dCustomNetworkTransform_SnapTo(CustomNetworkTransform* __this, Vector2 position, uint16_t minSid, MethodInfo* method) {
-    if (State.ShowHookLogs) Log.HookDebug("Hook dCustomNetworkTransform_SnapTo executed", false);
-    /*try {//Leave this out until we fix it.
-        if (!State.PanicMode) {
-            if (!IsInGame()) {
-                CustomNetworkTransform_SnapTo(__this, position, minSid, method);
-                return;
-            }
-
-            for (auto p : GetAllPlayerControl()) {
-                if (p->fields.NetTransform == __this) {
-                    PlayerSelection pSel = PlayerSelection(p);
-                    if (bogusTransformSnap(pSel, position))
-                    {
-                        synchronized(Replay::replayEventMutex) {
-                            State.liveReplayEvents.emplace_back(std::make_unique<CheatDetectedEvent>(GetEventPlayer(GetPlayerData(p)).value(), CHEAT_ACTIONS::CHEAT_TELEPORT));
-                        }
+void dCustomNetworkTransform_HandleRpc(CustomNetworkTransform* __this, uint8_t callId, MessageReader* reader, MethodInfo* method)
+{
+    if (State.ShowHookLogs) Log.HookDebug("Hook dCustomNetworkTransform_HandleRpc executed", false);
+    if (__this && __this->fields.myPlayer && State.SMAC_CheckTeleports && callId == 21)
+    {
+        PlayerControl* player = __this->fields.myPlayer;
+        if (!State.InMeeting && !player->fields.inVent)
+        {
+            try
+            {
+                const uint8_t playerId = player->fields.PlayerId;
+                if (State.mapType == Settings::MapType::Airship && State.SMAC_AirshipSpawnWhitelistedPlayers.erase(playerId) > 0) {
+                    Log.Debug(std::format("SMAC: ignored Airship spawn SnapTo for player {}", static_cast<int>(playerId)));
+                }
+                else if (IsInLobby()) {
+                    synchronized(Replay::replayEventMutex) {
+                        EVENT_PLAYER eventPlayer(GetPlayerData(player));
+                        State.liveReplayEvents.emplace_back( std::make_unique<CheatDetectedEvent>(eventPlayer, CHEAT_ACTIONS::CHEAT_TELEPORT));
+                        State.liveConsoleEvents.emplace_back(std::make_unique<CheatDetectedEvent>(eventPlayer, CHEAT_ACTIONS::CHEAT_TELEPORT));
                     }
-                    break;
+
+                    SMAC_OnCheatDetected(player, "Teleporting");
+                }
+                else {
+                    int32_t& count = State.SMAC_SnapToCount[playerId];
+                    ++count;
+
+                    if (count > 1) {
+                        synchronized(Replay::replayEventMutex) {
+                            EVENT_PLAYER eventPlayer(GetPlayerData(player));
+                            State.liveReplayEvents.emplace_back(std::make_unique<CheatDetectedEvent>(eventPlayer, CHEAT_ACTIONS::CHEAT_TELEPORT));
+                            State.liveConsoleEvents.emplace_back(std::make_unique<CheatDetectedEvent>(eventPlayer, CHEAT_ACTIONS::CHEAT_TELEPORT));
+                        }
+
+                        SMAC_OnCheatDetected(player, "Teleporting");
+                    }
+                }
+            }
+            catch (...) {
+                LOG_ERROR("Exception occurred in CustomNetworkTransform_HandleRpc");
+            }
+        }
+    }
+
+    CustomNetworkTransform_HandleRpc(__this, callId, reader, method);
+}
+
+void dCustomNetworkTransform_SnapTo(CustomNetworkTransform* __this, Vector2 position, uint16_t minSid, MethodInfo* method)
+{
+    if (State.ShowHookLogs) Log.HookDebug("Hook dCustomNetworkTransform_SnapTo executed", false);
+    try {
+        if (__this && __this->fields.myPlayer && State.SMAC_CheckTeleports && State.mapType == Settings::MapType::Airship) {
+            PlayerControl* player = __this->fields.myPlayer;
+            uint8_t playerId = player->fields.PlayerId;
+
+            if (IsAirshipSpawnPosition(position)) {
+                if (State.SMAC_AirshipSpawnWhitelistedPlayers.insert(playerId).second) {
+                    Log.Debug(std::format("SMAC: allowed Airship spawn teleport for player {} at ({:.2f}, {:.2f})", static_cast<int>(playerId), position.x, position.y));
                 }
             }
         }
     }
     catch (...) {
         LOG_ERROR("Exception occurred in CustomNetworkTransform_SnapTo (InnerNetClient)");
-    }*/
+    }
+
     CustomNetworkTransform_SnapTo(__this, position, minSid, method);
 }
 
 void dAmongUsClient_OnGameEnd(AmongUsClient* __this, EndGameResult* endGameResult, MethodInfo* method) {
     if (State.ShowHookLogs) Log.HookDebug("Hook dAmongUsClient_OnGameEnd executed", false);
     try {
+        State.SMAC_SnapToCount.clear();
+        State.SMAC_AirshipSpawnWhitelistedPlayers.clear();
+        
         if (*Game::pLocalPlayer != NULL && GetPlayerData(*Game::pLocalPlayer)->fields.RoleType == RoleTypes__Enum::Shapeshifter)
             RoleManager_SetRole(Game::RoleManager.GetInstance(), *Game::pLocalPlayer, RoleTypes__Enum::Impostor, NULL);
         //fixes game crashing on ending with shapeshifter

--- a/hooks/_hooks.cpp
+++ b/hooks/_hooks.cpp
@@ -307,6 +307,7 @@ void DetourInitilization() {
 	HOOKFUNC(PlayerControl_CheckColor);
 	HOOKFUNC(PlayerPhysics_HandleRpc);
 	HOOKFUNC(LobbyNotificationMessage_SetUp);
+	HOOKFUNC(CustomNetworkTransform_HandleRpc);
 
 	if (!HookFunction(&(PVOID&)oPresent, dPresent, "D3D_PRESENT_FUNCTION")) return;
 
@@ -525,6 +526,7 @@ void DetourUninitialization()
 	UNHOOKFUNC(PlayerControl_CheckColor);
 	UNHOOKFUNC(PlayerPhysics_HandleRpc);
 	UNHOOKFUNC(LobbyNotificationMessage_SetUp);
+	UNHOOKFUNC(CustomNetworkTransform_HandleRpc);
 
 	if (DetourDetach(&(PVOID&)oPresent, dPresent) != 0) return;
 

--- a/hooks/_hooks.h
+++ b/hooks/_hooks.h
@@ -11,6 +11,7 @@ void dAmongUsClient_OnGameJoined(AmongUsClient* __this, String* gameIdString, Me
 void dPlayerControl_OnGameStart(PlayerControl* __this, MethodInfo* method);
 void dAmongUsClient_OnPlayerLeft(AmongUsClient* __this, ClientData* data, DisconnectReasons__Enum reason, MethodInfo* method);
 void dAmongUsClient_OnPlayerJoined(AmongUsClient* __this, ClientData* data, MethodInfo* method);
+void dCustomNetworkTransform_HandleRpc(CustomNetworkTransform* __this, uint8_t callId, MessageReader* reader, MethodInfo* method);
 void dCustomNetworkTransform_SnapTo(CustomNetworkTransform* __this, Vector2 position, uint16_t minSid, MethodInfo* method);
 //bool dPlayerBanData_get_IsBanned(PlayerBanData* __this, MethodInfo* method);
 float dShipStatus_CalculateLightRadius(ShipStatus* __this, NetworkedPlayerInfo* player, MethodInfo* method);

--- a/user/state.cpp
+++ b/user/state.cpp
@@ -480,6 +480,7 @@ void Settings::Load() {
         JSON_TRYGET("SMAC_CheckBadWords", this->SMAC_CheckBadWords);
         JSON_TRYGET("SMAC_BadWords", this->SMAC_BadWords);
         JSON_TRYGET("SMAC_CheckFriendcode", this->SMAC_CheckFriendcode);
+		JSON_TRYGET("SMAC_CheckTeleports", this->SMAC_CheckTeleports);
         if (j.contains("ChatPresets") && j["ChatPresets"].is_array()) {
             this->ChatPresets.clear();
             for (auto& p : j["ChatPresets"]) {
@@ -1165,6 +1166,7 @@ void Settings::Save() {
                 { "SMAC_CheckBadWords", this->SMAC_CheckBadWords },
                 { "SMAC_BadWords", this->SMAC_BadWords },
                 { "SMAC_CheckFriendcode", this->SMAC_CheckFriendcode },
+				{ "SMAC_CheckTeleports", this->SMAC_CheckTeleports },
                 { "ChatPresets", [&]() {
                     nlohmann::json arr = nlohmann::json::array();
                     for (auto& p : this->ChatPresets) {

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -779,6 +779,7 @@ public:
     bool SMAC_CheckBadWords = true;
     std::vector<std::pair<std::string, bool>> SMAC_BadWords = {}; 
     bool SMAC_CheckFriendcode = true;
+    bool SMAC_CheckTeleports = false;
     bool SMAC_CheckStartWords = false;
     int SMAC_StartWordsThreshold = 1;
     std::vector<std::pair<std::string, bool>> SMAC_StartWords = {}; 
@@ -797,6 +798,8 @@ public:
     std::vector<std::string> LockedNames = {};
 
     std::unordered_set<uint8_t> SMAC_PunishedPlayers;
+    std::unordered_map<uint8_t, int32_t> SMAC_SnapToCount;
+    std::unordered_set<uint8_t> SMAC_AirshipSpawnWhitelistedPlayers;
 
     std::string lol = "";
     bool ProGamer = false;

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -813,11 +813,6 @@ Vector2 GetSpawnLocation(Game::PlayerId playerId, int32_t numPlayer, bool initia
     return { (spawncenter.x + 1) * (float)(playerId - 5), spawncenter.y * (float)(playerId - 5) };
 }
 
-bool IsAirshipSpawnLocation(const Vector2& vec)
-{
-    return (State.mapType == Settings::MapType::Airship);
-}
-
 Vector2 Rotate(const Vector2& vec, float degrees)
 {
     float f = 0.017453292f * degrees;

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -3036,3 +3036,25 @@ std::string GetDisconnectReasonString(DisconnectReasons__Enum reason) {
         return "Unknown";
     }
 }
+
+bool IsAirshipSpawnPosition(Vector2 position) {
+    constexpr float tolerance = 1.0f;
+
+    const Vector2 airshipSpawns[] = {
+        { -7.0f, -11.0f }, // Kitchen
+        { -0.7f,   8.5f }, // Brig
+        { 20.0f,  10.5f }, // Archive
+        { -0.7f,  -1.0f }, // Engines
+        { 15.5f,   0.0f }, // Main Hall
+        { 33.5f,  -1.5f }  // Storage
+    };
+
+    for (const auto& spawn : airshipSpawns) {
+        const float dx = position.x - spawn.x;
+        const float dy = position.y - spawn.y;
+
+        if ((dx * dx + dy * dy) <= tolerance * tolerance) return true;
+    }
+
+    return false;
+}

--- a/user/utility.cpp
+++ b/user/utility.cpp
@@ -1954,11 +1954,13 @@ void SMAC_OnCheatDetected(PlayerControl* pCtrl, std::string reason) {
     if (pCtrl == *Game::pLocalPlayer || (!IsInLobby() && !IsInMultiplayerGame())) return;
     if (reason == "Bad Sabotage" && !IsHost()) return;
 
+    // Teleport detection could be work bad with 3.0f flag cooldown. Removing it = solving issue
+    // I didn't notice any difference in DEBUG between 3.0f and without cooldown with 15/15 players
     static std::unordered_map<std::string, std::chrono::steady_clock::time_point> smacLastFlagTime;
     std::string smacFlagKey = std::to_string(pCtrl->fields.PlayerId) + "|" + reason;
     auto smacNow = std::chrono::steady_clock::now();
     auto smacFlagIt = smacLastFlagTime.find(smacFlagKey);
-    if (smacFlagIt != smacLastFlagTime.end() && std::chrono::duration<float>(smacNow - smacFlagIt->second).count() < 3.0f) return;
+    if (smacFlagIt != smacLastFlagTime.end() && std::chrono::duration<float>(smacNow - smacFlagIt->second).count() < 0.0f) return; // 0.0 FOR ANTI-TELEPORT
     smacLastFlagTime[smacFlagKey] = smacNow;
 
     auto pData = GetPlayerData(pCtrl);

--- a/user/utility.h
+++ b/user/utility.h
@@ -248,7 +248,7 @@ il2cpp::List<List_1_InnerNet_ClientData_> GetAllClients();
 Vector2 GetSpawnLocation(Game::PlayerId playerId, int numPlayer, bool initialSpawn);
 void GeneratePlatformId();
 std::string GetDisconnectReasonString(DisconnectReasons__Enum reason);
-bool IsAirshipSpawnLocation(const Vector2& vec);
+bool IsAirshipSpawnPosition(Vector2 position);
 Vector2 Rotate(const Vector2& vec, float degrees);
 bool Equals(const Vector2& vec1, const Vector2& vec2);
 std::string ToString(Object* object);


### PR DESCRIPTION
## SMAC
- Added new SMAC Detection: ``Abnormal Movements`` [Teleporting] (You can call it something else, idk)

**Known issue**: If we are not the host, fake detection may be displayed in the logs.
Reasons: spawning in map, calling a meeting

P.S. utility.cpp: Set 0.0f instead of 3.0f in smacLastFlagTime for working feature better than with cd...

Feature has bugs, so this pr was created solely for checking code;
unfinished yet