### PR TITLE
Fix cancel start keybind

### DIFF
--- a/hooks/DirectX.cpp
+++ b/hooks/DirectX.cpp
@@ -147,6 +147,8 @@ LRESULT __stdcall dWndProc(const HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
         if (KeyBinds::IsKeyPressed(State.KeyBinds.Complete_Tasks) && IsInGame()) CompleteAllTasks();
         if (KeyBinds::IsKeyPressed(State.KeyBinds.Leave_Game) && (IsInGame() || IsInLobby()) && !State.PanicMode)
             app::AmongUsClient_ExitGame((*Game::pAmongUsClient), DisconnectReasons__Enum::ExitGame, NULL);
+        if (KeyBinds::IsKeyPressed(State.KeyBinds.Cancel_Start) && IsInLobby() && State.IsStartCountdownActive)
+            State.CancelingStartGame = true;
     }
     if (KeyBinds::IsKeyPressed(State.KeyBinds.Toggle_Sicko)) {
         State.PanicMode = !State.PanicMode;

--- a/user/keybinds.cpp
+++ b/user/keybinds.cpp
@@ -238,4 +238,5 @@ void KeyBinds::from_json(const nlohmann::ordered_json& j, KeyBinds::Config& valu
     j.at("Complete_Tasks").get_to(value.Complete_Tasks);
     j.at("Toggle_Sicko").get_to(value.Toggle_Sicko);
     j.at("Leave_Game").get_to(value.Leave_Game);
+    j.at("Cancel_Start").get_to(value.Cancel_Start);
 }


### PR DESCRIPTION
The “Cancel Start of Game” keybind did nothing, so this has been fixed now.